### PR TITLE
Adds a backend testing lesson

### DIFF
--- a/testing-and-tdd/backend-testing.md
+++ b/testing-and-tdd/backend-testing.md
@@ -1,10 +1,14 @@
-> TODO:
-> - proofread
-> - move all @falun repl.it to something owned by techtonica
-> - lol :sob: rewrite probably; at minimum revisit external service testing bit at the end
-> - slides
-
 # Adding Unit Tests to your NodeJS project
+[//]: # (TODO)
+[//]: # (  - Still need slides)
+[//]: # (  - This hasn't really been proofed yet and I'm _real bad_ about typos <3)
+[//]: # (  - we should move all the @falun owned repl.it links to techtonica)
+[//]: # (  - the backend snapshots should start move off my elephantsql.com account)
+[//]: # (    at some point I'll delete the database it's using which will break the) 
+[//]: # (    sample; when we _do_ rehome the sample change the following links:)
+[backend-i]: https://repl.it/@falun/BackendTesting-I
+[backend-ii]: https://repl.it/@falun/BackendTesting-II
+[backend-iii]: https://repl.it/@falun/BackendTesting-III
 
 ### Projected Time
 
@@ -82,12 +86,33 @@ help provide depth to your understanding of API testing.
 
 - Slideshow &mdash; pending
 - [7 HTTP methods every web developer should know and how to test them][testing-http-methods]
-- [Testing a Database][db-testing-alt] &mdash; optional reading; this discusses
-  an alternate approach to DB testing than we'll take at a very high level.
+
+Code samples included in this lession
+- [Step 1][backend-i] &mdash; a snapshot of the TODO app that is works but is
+  neither tested nor built to facilitate testing
+- [Step 2][backend-ii] &mdash; the TODO app has gotten a basic set of unit
+  tests that protect against functional regressions and demonstrates how to
+  test an external service dependency
+- [Step 3][backend-iii] &mdash; with one final structural change our sample app
+  enables (and adds) testing for the code that interacts with our database
+
+Optional reading that was useful while writing this lesson:
+- [Testing a Database][db-testing-alt] &mdash; this discusses an alternate
+  approach to DB testing than we'll take at a very high level.
+- [`node-postgres` structure suggestion][postgres-structure]
+- [The Express API][express-api]
+- [superagent api][superagent-home] &mdash; this is the API underlying `supertest`
+- [Using PostgreSQL with Node.js][nodejs-postgres] &mdash; A simple example of 
+  using PostgreSQL within the context of a Node.js project (_not_ Express which
+  does have some impact)
+
 
 [testing-http-methods]: https://assertible.com/blog/7-http-methods-every-web-developer-should-know-and-how-to-test-them
 [db-testing-alt]: https://www.xaprb.com/blog/2008/08/19/how-to-unit-test-code-that-interacts-with-a-database/
-
+[postgres-structure]:https://node-postgres.com/guides/project-structure
+[express-api]: https://expressjs.com/en/4x/api.html
+[superagent-home]: https://visionmedia.github.io/superagent/
+[nodejs-postgres]: https://linuxhint.com/postgresql-nodejs-tutorial/
 ## Lesson
 
 ### Establishing some terminology
@@ -195,9 +220,6 @@ response you've configured, if not it will result in a test failure.
 **An Example:**
 
 ```javascript
-// TODO: this example taken ~directly from the scotch.io page, should probably
-// vary it -- it feels icky to just lift it
-
 // A simple function that we want to test; it makes an HTTP request to github
 // to retrieve a user object. It returns the result in a Promise.
 function getUser(username) {
@@ -478,12 +500,14 @@ running that connects to your database and gets you started managing and viewing
 TODO items. Don't worry about tests just yet, we'll make some changes that make
 it easier.
 
-**Challenge**: Once you've got the three methods up and working look at how we
+**Challenge**:  
+Once you've got the three methods up and working look at how we
 refactored the read methods to make DB accesses easier to read and maintain with
 `getTodo`. Rewrite the `POST /` handler to use a similar approach so that the
 handler doesn't have SQL directly inside it.
 
-**Reference implementation** Once you have it working there is a reference
+**Reference implementation**  
+Once you have it working there is a reference
 implementation on [repl.it][backend-i] if you want to see what some other
 potential solutions look like.
 
@@ -612,14 +636,16 @@ describe('GET /', () => {
 })
 ```
 
-**Challenge:** Take some time to get a feeling of how this works. Once there
+**Challenge:**  
+Take some time to get a feeling of how this works. Once there
 try to take the concepts in it and write unit tests for the case where the
 database calls fail. Now write the `POST /` test.
 
 What about things that aren't databases? How would you use the same principles
 to build testable code that utilizes external services?
 
-**Reference Implementation:** One possible way of doing this is up on
+**Reference Implementation:**  
+One possible way of doing this is up on
 [repl.it][backend-ii].
 
 #### Testing external services
@@ -631,10 +657,10 @@ are so let's start there.
 Up to now we've been using the concept of abstraction to hide database
 interactions behind a function that we pass around (like `saveTodo`). In that
 case let's figure out what it means for `saveTodo` to work. Well, the unit of
-functionality it's responsible is taking any arguments that are passed in and
-making sure that the correct SQL statements are executed. It's also responsible
-for making sure that if the database returns an error or something unexpected
-that it gets reported correctly to the calling code.
+functionality it's responsible for is taking any arguments that are passed in
+and making sure that the correct SQL statements are executed. It's also
+responsible for making sure that if the database returns an error or something
+unexpected that it gets reported correctly to the calling code.
 
 From this description it sounds like we want to treat the actual execution of
 that query as kind of a black box -- we let the library we use to interact with
@@ -691,64 +717,79 @@ setup.constructRoutes(app, ..., saveTodo)
 > The answer is one of mental framing: When deciding what to pull out I
 > approached it as a problem of "How do I make the database a variable." Within
 > that context it made more sense for `dbPool` to be passed in. This also means
-> if I need to do other things with the database in the future it doesn't change
+> if I need to do other things with the database in the future it doesn't
+> change. Even so if you wanted to just pass in a `query` function that is also
+> totally fine.
 >
 > Second: Once you dig into the reference project provided for part three
-> you'll notice it's different than the one above, why is that?
+> you'll notice the solution there is a bit different than the one above, why
+> is that?
 >
 > Mostly it's just that there are a lot of ways to solve programming problems
 > and often the same person will come up with different solutions. There isn't
-> any deep reason.
+> any deep reason. And ultimately the "best" solution is just a matter of
+> preference anyway.
 
 Now that we've abstracted out how the database gets provided to `saveTodo` the
 same approach we utilized for testing our handlers early in this lesson can be
-used to test our code that makes calls into the database.
+used to test our code that makes calls into the database. It turns out that
+when we want to make complex verifications around how a mock is called doing
+that all manually is a lot of work... that somebody else has done for us.
 
-> **Challenge:** It's an interesting task to do that, too! If you want to
-
-The solution here is actually very similar to the approach we took to make our
-endpoint handlers testable: we parameterize our code and inject the parts that
-we don't want to test. For the database that means the library responsible for
-actually executing our SQL on the database:
+Now we introduce the last new library of this lession,
+[simple-mock][simplemock-home]. At its most basic you can include the library
+and create new objects that act as a proxy for a function that you want to test
+your code's interactions with. As an example:
 
 ```javascript
-function init(dbPool) {
-  return {
-    getTodoDB: function(callbackFn) {
-      return dbPool.query('SELECT id, entry FROM todo_items', callbackFn)
-    }
+// include the libraries
+const expect = require('chai').expect
+const simple = require('simple-mock')
+
+// and we have a function we want to test
+function functionToTest(functionToCall, callNTimes) {
+  for (let i = 0; i < callNTimes; i++) {
+    functionToCall(i)
   }
 }
 
-// In use this would look similar to:
-const dbPool = ...        // connect to database
-const data = init(dbPool) // set up the database API
-const app = express()     // build the express app
+describe('functionToTest', () => {
+  it('should call the passed-in function once', () => {
+    // create a mock function to pass in to `functionToTest`
+    const mockFn = simple.mock()
+    functionToTest(mockFn, 1)
 
-// register the handles to app and tell them to use the real DB functions
-constructRoutes(app, data.getTodoDB)
+    // verify that mockFn was called once
+    expect(mockFn.calls.length).to.equal(1)
+
+    // grab the first call to mockFn
+    const callArgs = mockFn.calls[0].args
+
+    // verify that functionToTest only passed one parameter
+    expect(callArgs.length).to.equal(1)
+    // ...and that the parameter's value was 1
+    expect(callArgs.length[0]).to.equal(1)
+  })
+})
 ```
 
-To test this we would call `init` and pass in a mock that allowed us to verify
-`query` got called with the right arguments. The reference implementation
-[simple-mock][simplemock-home] to make validation simple. You can find it on
-[repl.it][backend-iii].
+This is enough for you to get a solid collection of tests going for the code
+that calls your database but `simple-mock` is much more featureful and it's
+worth looking into the different testing / validation modes it supports later.
 
-[backend-i]: https://repl.it/@falun/BackendTesting-I
-[backend-ii]: https://repl.it/@falun/BackendTesting-II
-[backend-iii]: https://repl.it/@falun/BackendTesting-III
+**Challenge:**  
+It's an interesting task to implement your own mocking and validation code by
+hand and teaches you a lot of neat tricks. If you're feeling adventurous give
+that a try!
 
-**Reference material**
-
-I found these sites useful in the process of writing this lesson
-- `node-postgres` structure suggestion - https://node-postgres.com/guides/project-structure
-- Express API - https://expressjs.com/en/4x/api.html
-- [supertest](https://github.com/visionmedia/supertest) and [superagent](https://visionmedia.github.io/superagent/) docs
-- [Using PostgreSQL with Node.js](https://linuxhint.com/postgresql-nodejs-tutorial/) &mdash; note that this is not within the
+**Reference implementation:**  
+As normal we have a reference project that complets testing your database
+interaction code available in a [repl.it][backend-iii].
 
 ### Independent Practice
 
-- Deploy your own version of the sample TODO project to heroku, netlify, or similar
+- Deploy your own version of the sample TODO project to heroku, netlify, or
+  similar
 - Experiment with Postman to create new TODO item
 - Add a test for `/items` to make sure that the HTML version displays as we
   expect; don't forget to include the case where your DB call fails
@@ -759,8 +800,10 @@ Try to expand the sample TODO app that we've written:
 - Enable requests that get specific TODO items
 - Support deleting a TODO item
 - Add TODO lists that are specific to different users of the system
-- Add an endpoint to implement marking an item as completed (and update the database schema, too)
-- Use the principles we spoke about when testing an external Database to test an external HTTP service
+- Add an endpoint to implement marking an item as completed (and update the
+  database schema, too)
+- Use the principles we spoke about when testing an external Database to test
+  an external HTTP service
 
 And, of course, write unit tests for each of your new features!
 

--- a/testing-and-tdd/backend-testing.md
+++ b/testing-and-tdd/backend-testing.md
@@ -475,8 +475,8 @@ dbPool.on('error', (err, client) => {
 ```
 
 After this we can make queries to the database by using `dbPool.query(...)`.
-It's documentation is [here][pq-query] but the short is that it takes three
-arguments:
+Its documentation is [here][pq-query] but the short version is that it takes
+three arguments:
 1. the query to be run, e.g., `SELECT * from todo_items`
 2. (optional) any arguments that are passed into the query
 3. a callback that will be made once the query is completed

--- a/testing-and-tdd/backend-testing.md
+++ b/testing-and-tdd/backend-testing.md
@@ -205,7 +205,7 @@ items 1 & 2. It additionally helps address the potential time and money costs
 that making actual calls to the service would introduce into our tests (item
 3).
 
-> The concept of **mocking** was covered in [Intro to Testing][intro-to-testing].
+> The concept of **mocking** was covered in [Intro to Testing][tt-testing-intro].
 >
 > As a brief refresher: it is a technique of providing an implementation of an
 > interface which allows you to specify exactly what the return value should be

--- a/testing-and-tdd/backend-testing.md
+++ b/testing-and-tdd/backend-testing.md
@@ -1,8 +1,6 @@
 > TODO:
 > - proofread
-> - "Check for understanding" section
 > - move all @falun repl.it to something owned by techtonica
-> - collect and review all linked material
 > - lol :sob: rewrite probably; at minimum revisit external service testing bit at the end
 > - slides
 
@@ -16,10 +14,8 @@ XX minutes
 
 Here are links to lessons that should be completed before this lesson:
 
-- [Intro to Testing and TDD][intro-to-testing]
-- [Jasmine Testing](jasmine-testing.md)
-
-[intro-to-testing]: testing-and-tdd.md
+- [Intro to Testing and TDD][tt-testing-intro]
+- [Jasmine Testing][tt-testing-frameworks]
 
 ### Motivation
 
@@ -47,27 +43,50 @@ maintainability of our projects.
 
 ### Specific Things To Teach
 
+> **Note**: We've included links to guides on each of these when available for
+> easy reference later. These are also included when applicable during the
+> lesson.
+
 - General testing tools
-  - Mocha
-  - Chai
-  - Postman
+  - [Mocha][mocha-home] ([Intro To Testing][tt-testing-frameworks])
+  - [Chai][chai-home] ([Intro To Testing][tt-testing-frameworks])
+  - [Postman][postman-home] (guides to: [Navigating Postman][postman-nav], [Making GET requests][postman-get], [Making POST requests][postman-post])
 - Testing external services
   - Mocking & abstractions
-  - Simple Mock
-  - Nock
+  - [Simple Mock][simplemock-home]
+  - [Nock][nock-home] ([intro tutorial][nock-intro])
 - Testing HTTP requests to your project
-  - Supertest
+  - [Supertest][supertest-home] ([intro tutorial][supertest-intro])
 - Testing your own database
+
+[tt-testing-intro]: /testing-and-tdd/testing-and-tdd.md
+[tt-testing-frameworks]: jasmine-testing.md
+[mocha-home]: https://mochajs.org/
+[chai-home]: https://www.chaijs.com/
+[postman-home]: https://www.getpostman.com/
+[simplemock-home]: https://www.npmjs.com/package/simple-mock
+[supertest-home]: https://www.npmjs.com/package/supertest
+[supertest-intro]: https://codeforgeek.com/2015/07/unit-testing-nodejs-application-using-mocha/
+[nock-home]: https://github.com/nock/nock
+[nock-intro]: https://scotch.io/tutorials/nodejs-tests-mocking-http-requests
+[postman-nav]: https://www.toolsqa.com/postman/postman-navigation/
+[postman-get]: https://www.toolsqa.com/postman/response-in-postman/
+[postman-post]: https://www.toolsqa.com/postman/post-request-in-postman/
+
 
 ### Materials
 
-[Link to slideshow](pending)
+In additional to the linked material above associated with specific
+technologies that we'll be using there is some more general reading that will
+help provide depth to your understanding of API testing.
 
-[Node.js Tests: Mocking HTTP Requests][scotch-nock]
+- Slideshow &mdash; pending
+- [7 HTTP methods every web developer should know and how to test them][testing-http-methods]
+- [Testing a Database][db-testing-alt] &mdash; optional reading; this discusses
+  an alternate approach to DB testing than we'll take at a very high level.
 
-[7 HTTP methods every web developer should know and how to test them](https://assertible.com/blog/7-http-methods-every-web-developer-should-know-and-how-to-test-them)
-
-[Testing a Database](https://www.xaprb.com/blog/2008/08/19/how-to-unit-test-code-that-interacts-with-a-database/)
+[testing-http-methods]: https://assertible.com/blog/7-http-methods-every-web-developer-should-know-and-how-to-test-them
+[db-testing-alt]: https://www.xaprb.com/blog/2008/08/19/how-to-unit-test-code-that-interacts-with-a-database/
 
 ## Lesson
 
@@ -168,7 +187,7 @@ that making actual calls to the service would introduce into our tests (item
 > when a specific call is made. Additionally, it enables you to verify that the
 > interface was called with the expected values.
 
-In order to mock backend calls we'll be using a library called [`nock`][nock].
+In order to mock backend calls we'll be using a library called [`nock`][nock-home].
 Nock works by intercepting HTTP requests that your code makes checking against
 what you've instructed it to expect. If it finds a match it will return the
 response you've configured, if not it will result in a test failure.
@@ -223,7 +242,7 @@ describe('Get User tests', () => {
 });
 ```
 
-> The above example is taken from [scoth.io][scotch-nock]; visit this page to
+> The above example is taken from [scoth.io][nock-intro]; visit this page to
 > see a more detailed example with additional explanation.
 
 **Exercise**
@@ -232,9 +251,6 @@ describe('Get User tests', () => {
 2. How do you think this would change if we changed `mockObject.id` to be `42`?
 3. How do you think this would change if we changed `mockObject.name` to
    `Techtonica`?
-
-[nock]: https://github.com/nock/nock
-[scotch-nock]: https://scotch.io/tutorials/nodejs-tests-mocking-http-requests
 
 #### Abstraction
 
@@ -363,10 +379,6 @@ has good collection of Postman covering basic and enterprise uses. For now
 you should skim the [navigation][postman-nav], [GET request][postman-get], and
 [POST request][postman-post] tutorials.
 
-[postman-nav]: https://www.toolsqa.com/postman/postman-navigation/
-[postman-get]: https://www.toolsqa.com/postman/response-in-postman/
-[postman-post]: https://www.toolsqa.com/postman/post-request-in-postman/
-
 **Why use Postman?**
 When building an API it's often _much_ easier to wire up a test request in
 Postman than to build an HTML form (or similar) to fire off some test requests
@@ -481,8 +493,6 @@ Read through [Testing Node.js with supertest][supertest-intro]. Much of this
 will be familiar but it introduces a new library called `supertest`. At its
 core this allows you to easily do in your unit tests what Postman was letting
 you do to experiment.
-
-[supertest-intro]: https://codeforgeek.com/2015/07/unit-testing-nodejs-application-using-mocha/
 
 #### Refactoring for API Tests
 
@@ -615,6 +625,87 @@ to build testable code that utilizes external services?
 #### Testing external services
 
 To wrap things up we still want to make sure that our database code is tested.
+Before jumping into code it's always a good idea to think about what your goals
+are so let's start there.
+
+Up to now we've been using the concept of abstraction to hide database
+interactions behind a function that we pass around (like `saveTodo`). In that
+case let's figure out what it means for `saveTodo` to work. Well, the unit of
+functionality it's responsible is taking any arguments that are passed in and
+making sure that the correct SQL statements are executed. It's also responsible
+for making sure that if the database returns an error or something unexpected
+that it gets reported correctly to the calling code.
+
+From this description it sounds like we want to treat the actual execution of
+that query as kind of a black box -- we let the library we use to interact with
+our database deal with that (in our case `pg`) and just make sure that we pass
+the right input to `.query` and handle the output correctly. That sounds an
+awful lot we might want to mock the actual database doesn't it?
+
+Let's look at the current `saveTodo` implementation (taken from second stage
+version of our [reference TODO project][backend-ii]):
+
+```javascript
+function saveTodoDB(todo, callbackFn) {
+  return dbPool.query(
+    'INSERT INTO todo_items (entry) VALUES($1)',
+    [todo],
+    callbackFn)
+}
+```
+
+We can use the same principles of encapsulation and injection here to make the
+`dbPool` a variable that gets passed in allowing us to provide a mocked
+implementation for testing. This is applying the same pattern we used before
+to make our API endpoint handlers testable. First we made the code parameterized
+by the thing we wanted to replace:
+
+```javascript
+function mkSaveTodo(dbPool) {
+  return function(todo, callback) {
+    return dbPool.query(
+      'INSERT INTO todo_items (entry) VALUES($1)',
+      [todo],
+      callbackFn)
+  }
+}
+```
+
+and then we can use this to get a version of `saveTodo` function that uses the
+correct database backend for our API. We then pass that into the
+`constructRoutes` call:
+
+```javascript
+// Note, while much of the code in this lesson omits a lot of context due to
+// its nature this sample is omiting more than normal...
+const dbPool = new pg.Pool({ connectionString: dbConnString })
+const saveTodo = mkSaveTodo(dbPool)
+setup.constructRoutes(app, ..., saveTodo)
+```
+
+> Note: There are two things worth calling out a about this example.
+>
+> First: A totally valid question is "why not have `mkSaveTodo` take in a
+> `query` function instead of `dbPool`?
+>
+> The answer is one of mental framing: When deciding what to pull out I
+> approached it as a problem of "How do I make the database a variable." Within
+> that context it made more sense for `dbPool` to be passed in. This also means
+> if I need to do other things with the database in the future it doesn't change
+>
+> Second: Once you dig into the reference project provided for part three
+> you'll notice it's different than the one above, why is that?
+>
+> Mostly it's just that there are a lot of ways to solve programming problems
+> and often the same person will come up with different solutions. There isn't
+> any deep reason.
+
+Now that we've abstracted out how the database gets provided to `saveTodo` the
+same approach we utilized for testing our handlers early in this lesson can be
+used to test our code that makes calls into the database.
+
+> **Challenge:** It's an interesting task to do that, too! If you want to
+
 The solution here is actually very similar to the approach we took to make our
 endpoint handlers testable: we parameterize our code and inject the parts that
 we don't want to test. For the database that means the library responsible for
@@ -640,13 +731,12 @@ constructRoutes(app, data.getTodoDB)
 
 To test this we would call `init` and pass in a mock that allowed us to verify
 `query` got called with the right arguments. The reference implementation
-[simple-mock][simple-mock] to make validation simple. You can find it on
+[simple-mock][simplemock-home] to make validation simple. You can find it on
 [repl.it][backend-iii].
 
 [backend-i]: https://repl.it/@falun/BackendTesting-I
 [backend-ii]: https://repl.it/@falun/BackendTesting-II
 [backend-iii]: https://repl.it/@falun/BackendTesting-III
-[simple-mock]: https://github.com/jupiter/simple-mock#mock
 
 **Reference material**
 
@@ -658,7 +748,7 @@ I found these sites useful in the process of writing this lesson
 
 ### Independent Practice
 
-- Deploy your own version of the sample TODO project to heroku
+- Deploy your own version of the sample TODO project to heroku, netlify, or similar
 - Experiment with Postman to create new TODO item
 - Add a test for `/items` to make sure that the HTML version displays as we
   expect; don't forget to include the case where your DB call fails
@@ -676,8 +766,13 @@ And, of course, write unit tests for each of your new features!
 
 ### Check for Understanding
 
-> Some ideas: have apprentices summarize to each other, make a cheat sheet, take
-> a quiz, do an assignment, or something else that helps assess their
-> understanding.
-
-TODO
+- Pair up with another apprentice and do a Q&A on backend testing; some example
+  topics:
+  - How API / backend testing is different from unit tests you've previously
+    written
+  - What are the benefits of not testing against live external services
+  - Discuss the concepts of abstraction, mocks, and higher-order functions and
+    how we apply them in testing
+- Trade code with another apprentice and review their solution to find how they
+  used the principles we discussed; are there any improvements you can find for
+  better readability or maintainability?

--- a/testing-and-tdd/backend-testing.md
+++ b/testing-and-tdd/backend-testing.md
@@ -2,29 +2,39 @@
 
 ### Projected Time
 
-Example: 30-45 minutes
+XX minutes
 
 ### Prerequisites
 
 Here are links to lessons that should be completed before this lesson:
 
-- [Intro to Testing and TDD](testing-and-tdd.md)
+- [Intro to Testing and TDD][intro-to-testing]
 - [Jasmine Testing](jasmine-testing.md)
 
+[intro-to-testing]: testing-and-tdd.md
 
 ### Motivation
 
-Backend, or database, helps ensure that when your application makes an API call, the information sent and/or received behaves in the way you expect it to. This type of testing can be especially challenging, but crucial, if your application relies on an external API--say, gathering Yelp reviews--since the structure of the external database could change at any time.
+Up to now we've been talking about unit testing within the context of making
+sure that a single function behaves as we expect. In a real project though
+functions are often called by our users or rely on external services. We still
+want to ensure that our code works as expected though but testing these things
+introduce some new challenges.
 
+This lesson introduces new tools and code patterns that help us to meet those
+challenges.
+
+As a bonus the patterns we learn about to help design our code to facilitate
+its testing is also a good practice that will aid readability and long term
+maintainability of our codebase.
 
 ### Objectives
 
 **Participants will be able to:**
 
-- Explain the purpose and specific challenges of database testing
+- Explain the purpose and specific challenges of backend testing
 - Write code to test GET, PUT, POST and DELETE requests
 - Use mocks to mimic testing GET requests to an external API
-
 
 ### Specific Things To Teach
 
@@ -33,10 +43,9 @@ Backend, or database, helps ensure that when your application makes an API call,
 	- Chai
 	- Nock
 	- GUIs for testing HTTP requests (Postman)
-- Testing your own database
 - Testing external APIs
 	- Mocking
-
+- Testing your own database (&#x1F534; TODO: need additional information)
 
 ### Materials
 
@@ -46,16 +55,104 @@ Backend, or database, helps ensure that when your application makes an API call,
 
 [7 HTTP methods every web developer should know and how to test them](https://assertible.com/blog/7-http-methods-every-web-developer-should-know-and-how-to-test-them)
 
-### Lesson
+## Lesson
 
-Ensure apprentices have completed the Jasmine Testing lesson and are comfortable using Mocha and Chai and review if necessary.
+### Establishing some terminology
 
+Before we get started let's set some ground rules about how we use terminology.
+This lesson is called "backend testing" but without establishing what `backend`
+means that can easily get confusing.
 
+Within the context of this lesson a `backend` is an API that supports some
+collection of features. It often, but not always, exposes its interface through
+HTTP requests and returns JSON objects as a responses.
+
+A `backend` can be the service you're writing but it can also be something that
+you depend on:
+- a database may be a backend to your service
+- your service could be the backend to your users
+- the github API may be a backend you depend upon
+
+For this reason it's important to provide sufficient context when talking about
+using or testing a backend service.
+
+With that in mind...
+
+This lesson discusses backend testing in all of these frames: we will test your
+service's interaction with its backend (database & external APIs) while also
+writing tests to ensure your service, when used as a backend, performs as
+expected.
+
+### Getting Started: Is backend testing special?
+
+We've already talked about testing and how it's important to verify that the
+quality of its code remains high as you send it out into the world. Why then
+is it worth discussing backend testing, isn't that just more of the same?
+
+Well, kind of.
+
+Backend testing is important for the same reason: We need to ensure that our
+code works as expected and to protect correct behavior in the future as we
+make changes. So framed as "is testing important," yes backend testing can be
+pretty much thought of as just more of the same. However when you actually sit
+down to write these tests the interactions with external callers and APIs
+introduce interesting new difficulties.
+
+### Facing new challenges
+
+So what are some of these new challenges and how to we address them?
+
+1. We are often consumers of an external API and don't control its behavior;
+2. These APIs we use typically strive for uptime, given this how do we test our
+   project's behavior when those APIs fail;
+3. Making calls to external APIs or databases often requires network access (or
+   use of them is costly), both of which incentivize writing less comprehensize
+   tests;
+4. Running an API means we need to test our processing of HTTP requests which is
+  not necessarily technically obvious.
+
+There are other issues but learning how to address these is a great start and
+covers many of the foundational skills necessary to provide great test coverage
+for your project.
+
+### Key concepts
+
+#### Mocking
+
+The core of our backend tests will be built on the concept of providing mocked
+responses to external API calls. This allows us to take control over much of
+the complexity of interacting with other services that we discussed above in
+items 1 & 2. It additionally helps address the potential time and money costs
+that making actual calls to the service would introduce into our tests.
+
+> The concept of **mocking** was covered in [Intro to Testing][intro-to-testing].
+> As a brief refresher it is the act of providing a fake implementation of an
+> interface that allows you to specify exactly what the return value should be.
+> It additionally enables you to verify that the API was called with some
+> expected values.
+
+In order to mock the HTTP calls we'll be using a library called [`nock`][nock].
+Nock works by intercepting HTTP requests that your
+
+[nock]: https://github.com/nock/nock
+
+#### Experimentation
+
+TODO: discuss manually testing external APIs with postman
+
+#### Abstraction
+
+### Putting it all together
 
 ### Common Mistakes / Misconceptions
 
-- I need to constantly test the external APIs I'm using to make sure my code still works.
-	- Instead, write mock classes that return information in the format you expect it. In other words, assume that everything is okay on the external service's end. Use these mocks to test expected and unexpected behavior--this way you will be prepared for future unexpected external behavior without needing to hit an external API on every test.
+- I need to constantly test the external APIs I'm using to make sure my code
+  still works.
+	- Instead, write mock classes that return information in the format you
+    expect it. In other words, assume that everything is okay on the external
+		service's end. Use these mocks to test expected and unexpected behavior
+		&mdash; this way you will be prepared for future unexpected external
+		behavior without needing to hit an external API on every test.
 
 
 ### Guided Practice
@@ -76,4 +173,6 @@ Apprentices can try to do this other thing.
 
 ### Check for Understanding
 
-Some ideas: have apprentices summarize to each other, make a cheat sheet, take a quiz, do an assignment, or something else that helps assess their understanding.
+Some ideas: have apprentices summarize to each other, make a cheat sheet, take
+a quiz, do an assignment, or something else that helps assess their
+understanding.

--- a/testing-and-tdd/testing-and-tdd.md
+++ b/testing-and-tdd/testing-and-tdd.md
@@ -259,7 +259,7 @@ Ping Pong Pairing is a common technique when using TDD where each developer swit
 Users may be on many different web browsers so we need to test webpages for browser compatibility.
 - These will show how different websites look on multiple browsers to different users.
 [browserling](https://www.browserling.com/)
-[browser sandbox] (https://turbo.net/browsers)
+[browser sandbox](https://turbo.net/browsers)
 
 Other tests
 [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) Free tool by Google to test the speed of your website

--- a/testing-and-tdd/testing-and-tdd.md
+++ b/testing-and-tdd/testing-and-tdd.md
@@ -262,8 +262,8 @@ Users may be on many different web browsers so we need to test webpages for brow
 [browser sandbox] (https://turbo.net/browsers)
 
 Other tests
-[PageSpeed Insights] (https://developers.google.com/speed/pagespeed/insights/) Free tool by Google to test the speed of your website
-[10 Free UI Testing Tools] (http://smashinghub.com/10-free-web-ui-testing-tools.htm) Numerous online tools that you can use to test your website.
+[PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) Free tool by Google to test the speed of your website
+[10 Free UI Testing Tools](http://smashinghub.com/10-free-web-ui-testing-tools.htm) Numerous online tools that you can use to test your website.
 
 ### Check for Understanding
 


### PR DESCRIPTION
I made some minor changes to the backend testing lesson 😉

There are still a couple of things that need to be done; I've pulled them out in a non-rendering comment block at the top of the file but here it is for ease of reading:

```
[//]: # (TODO)
[//]: # (  - Still need slides)
[//]: # (  - This hasn't really been proofed yet and I'm _real bad_ about typos <3)
[//]: # (  - we should move all the @falun owned repl.it links to techtonica)
[//]: # (  - the backend snapshots should start move off my elephantsql.com account)
[//]: # (    at some point I'll delete the database it's using which will break the) 
[//]: # (    sample; when we _do_ rehome the sample change the following links:)
[backend-i]: https://repl.it/@falun/BackendTesting-I
[backend-ii]: https://repl.it/@falun/BackendTesting-II
[backend-iii]: https://repl.it/@falun/BackendTesting-III
```

There are no slides to go along with this for which I'm very sorry but simple ran out of time (I gave @alodahl a heads up so as to not surprise anybody). I can consult with whomever picks that up and have some ideas about how to present some of the more challenging stuff if folks are blocked.

Happy to make changes, hope this is helpful!

P.S. I fixed a few links in the `testing-and-tdd` doc