### PR TITLE
Add general tips to debugging lesson

### DIFF
--- a/debugging/debugging.md
+++ b/debugging/debugging.md
@@ -31,7 +31,6 @@
 - Bad debugging strategies
 
 ### Materials
-
 - [Get Started with Debugging JavaScript with Chrome Dev Tools (tutorial)](https://developers.google.com/web/tools/chrome-devtools/javascript/)
 
 ### Lesson
@@ -41,11 +40,25 @@
 ##### General Tips for Debugging (with VS Code)
 - When VS Code shows you a red squiggly underline then it's trying to help you so I insist you pay attention to the message.
 - If the red squiggly underline is under something that's clearly correct, like `color: red;` in a CSS file, then first check if it really is correct.
-- Pattern matching — It is a mechanism for checking a value against a pattern. In debugging you use pattern matching(inbuilt in VS Code) to match the syntax you write with the correct syntax which helps you to figure out errors in your code. For example, suppose you want to change the color of a text in CSS and you write `colour: blue;` then VS Code uses its pattern matching mechanism to match it again correct syntax and give you an error "check property spelling" as the correct form is `color: blue;`.
+- Pattern matching — It is a mechanism for checking a value against a pattern. In debugging you use pattern matching(built into VS Code) to match the syntax you write with the correct syntax which helps you to figure out errors in your code. For example, suppose you want to change the color of a text in CSS and you write `colour: blue;` then VS Code uses its pattern matching mechanism to match it again correct syntax and give you an error "check property spelling" as the correct form is `color: blue;`.
 - When you make a change on a file, and then visually when you refresh your page you don't see any changes then I suggest you go through the following points:
-    - Check whether you save the file? If you forget then I suggest you add autosave in VS Code, it will help you save the latest changes even if you forget.([How to add autosave in VS Code](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save))
-    - Make a temporary, very obvious change on your HTML page such as write some text in the top of the `body` or a prominent heading then save the file and reload the browser. Check whether you can see the text? If you can't see the new text, maybe you have the wrong file open, or the file didn't save, or something else very strange is happening.
-    - Make a temporary, very obvious change to your CSS file such as add `color: red;` to something extremely obvious like `body` or `h1` then save and reload the browser. Check whether the thing you expected to turn red actually turns red? If it doesn't, maybe the CSS file isn't getting loaded properly or check for syntax errors earlier in your CSS file that may render the rest of your CSS file inoperable or Are you missing a semicolon? did you use `=` instead of `:` accidentally? or are you missing a quotation mark in a font declaration, so your CSS file thinks there's a really long string somewhere? or are your curly braces correctly matched and closed?
+    - Check whether you saved the file. 
+        - If you forget then I suggest you add autosave in VS Code.
+        - It will help you save the latest changes even if you forget.
+        - ([How to add autosave in VS Code](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save))
+    - Make a temporary, very obvious change on your HTML page.
+        - Such as write some text in the top of the `body` or a prominent heading then save the file and reload the browser. 
+        - Check whether you can see the text. 
+        - If you can't see the new text, maybe you have the wrong file open, or the file didn't save, or something else very strange is happening.
+    - Make a temporary, very obvious change to your CSS file.
+        - such as add `color: red;` to something extremely obvious like `body` or `h1` then save and reload the browser. 
+        - Check whether the thing you expected to turn red actually turns red. 
+        - If it doesn't, maybe the CSS file isn't getting loaded properly or check for syntax errors earlier in your CSS file that may render the rest of your CSS file inoperable.
+        - Such as :
+            - Are you missing a semicolon? 
+            - Did you use `=` instead of `:` accidentally? 
+            - Are you missing a quotation mark in a font declaration, so your CSS file thinks there's a really long string somewhere?
+            - Are your curly braces correctly matched and closed?
 
 ### Common Mistakes / Misconceptions
 

--- a/debugging/debugging.md
+++ b/debugging/debugging.md
@@ -45,7 +45,7 @@
 - If the red squiggly underline is under something that's clearly correct, like `color: red;` in a CSS file, then first check if it really is correct.
 - The phrase "pattern matching" and why it's important: use other code snippets to remind yourself of correct syntax.
 - When you make a change on a file, and then visually when you refresh your page you don't see any changes, run through a quick checklist:
-    - Did you save? this kills me every time (see: add autosave to VS Code lesson if it's not already there).
+    - Did you save? this kills me every time ([add autosave to VS Code lesson if it's not already there](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save)).
     - Make a temporary, very obvious change on your HTML page. I write some text in the top of the body or a prominent heading. save the file and reload the browser. verify that you see the text. if you don't see the new text, maybe you have the wrong file open, or the file didn't save, or something else very strange is happening.
     - Make a temporary, very obvious change to your CSS file. I like to add `color: red;` to something extremely obvious like `body` or `h1`. Save and reload the browser and verify that the thing you expected to turn red actually turns red. If it doesn't, maybe the CSS file isn't getting loaded properly. or check for syntax errors earlier in your CSS file that may render the rest of your CSS file inoperable. Are you missing a semicolon? did you use `=` instead of `:` accidentally? are you missing a quotation mark in a font declaration, so your CSS file thinks there's a really long string somewhere? are your curly braces correctly matched and closed?
 

--- a/debugging/debugging.md
+++ b/debugging/debugging.md
@@ -35,19 +35,17 @@
 - [Get Started with Debugging JavaScript with Chrome Dev Tools (tutorial)](https://developers.google.com/web/tools/chrome-devtools/javascript/)
 
 ### Lesson
-
 - Video walkthrough of slides [Debugging (12 mins watch)](https://drive.google.com/file/d/1VMyGDG5CnNMkjCyaNx1LAjxTMKxC0QQ4/view?usp=sharing)
-
 - Read through lesson slides [Debugging](https://docs.google.com/presentation/d/1Ol1as_RuxBpXMd4VxCUyvFVkjpcqAxg6B-c0Sl9KDLc/edit?usp=sharing)
 
-##### General Tips
-- When VS Code shows you a red squiggly underline then it's trying to help you. So pay attention to the message.
+##### General Tips for Debugging (with VS Code)
+- When VS Code shows you a red squiggly underline then it's trying to help you so I insist you pay attention to the message.
 - If the red squiggly underline is under something that's clearly correct, like `color: red;` in a CSS file, then first check if it really is correct.
-- The phrase "pattern matching" and why it's important: use other code snippets to remind yourself of correct syntax.
-- When you make a change on a file, and then visually when you refresh your page you don't see any changes, run through a quick checklist:
-    - Did you save? this kills me every time ([add autosave to VS Code lesson if it's not already there](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save)).
-    - Make a temporary, very obvious change on your HTML page. I write some text in the top of the body or a prominent heading. save the file and reload the browser. verify that you see the text. if you don't see the new text, maybe you have the wrong file open, or the file didn't save, or something else very strange is happening.
-    - Make a temporary, very obvious change to your CSS file. I like to add `color: red;` to something extremely obvious like `body` or `h1`. Save and reload the browser and verify that the thing you expected to turn red actually turns red. If it doesn't, maybe the CSS file isn't getting loaded properly. or check for syntax errors earlier in your CSS file that may render the rest of your CSS file inoperable. Are you missing a semicolon? did you use `=` instead of `:` accidentally? are you missing a quotation mark in a font declaration, so your CSS file thinks there's a really long string somewhere? are your curly braces correctly matched and closed?
+- Pattern matching — It is a mechanism for checking a value against a pattern. In debugging you use pattern matching(inbuilt in VS Code) to match the syntax you write with the correct syntax which helps you to figure out errors in your code. For example, suppose you want to change the color of a text in CSS and you write `colour: blue;` then VS Code uses its pattern matching mechanism to match it again correct syntax and give you an error "check property spelling" as the correct form is `color: blue;`.
+- When you make a change on a file, and then visually when you refresh your page you don't see any changes then I suggest you go through the following points:
+    - Check whether you save the file? If you forget then I suggest you add autosave in VS Code, it will help you save the latest changes even if you forget.([How to add autosave in VS Code](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save))
+    - Make a temporary, very obvious change on your HTML page such as write some text in the top of the `body` or a prominent heading then save the file and reload the browser. Check whether you can see the text? If you can't see the new text, maybe you have the wrong file open, or the file didn't save, or something else very strange is happening.
+    - Make a temporary, very obvious change to your CSS file such as add `color: red;` to something extremely obvious like `body` or `h1` then save and reload the browser. Check whether the thing you expected to turn red actually turns red? If it doesn't, maybe the CSS file isn't getting loaded properly or check for syntax errors earlier in your CSS file that may render the rest of your CSS file inoperable or Are you missing a semicolon? did you use `=` instead of `:` accidentally? or are you missing a quotation mark in a font declaration, so your CSS file thinks there's a really long string somewhere? or are your curly braces correctly matched and closed?
 
 ### Common Mistakes / Misconceptions
 

--- a/debugging/debugging.md
+++ b/debugging/debugging.md
@@ -36,10 +36,18 @@
 
 ### Lesson
 
-[Debugging (video walkthrough of slides)](https://drive.google.com/file/d/1VMyGDG5CnNMkjCyaNx1LAjxTMKxC0QQ4/view?usp=sharing)
+- Video walkthrough of slides [Debugging (12 mins watch)](https://drive.google.com/file/d/1VMyGDG5CnNMkjCyaNx1LAjxTMKxC0QQ4/view?usp=sharing)
 
-[Debugging (slides)](https://docs.google.com/presentation/d/1Ol1as_RuxBpXMd4VxCUyvFVkjpcqAxg6B-c0Sl9KDLc/edit?usp=sharing)
+- Read through lesson slides [Debugging](https://docs.google.com/presentation/d/1Ol1as_RuxBpXMd4VxCUyvFVkjpcqAxg6B-c0Sl9KDLc/edit?usp=sharing)
 
+##### General Tips
+- When VS Code shows you a red squiggly underline then it's trying to help you. So pay attention to the message.
+- If the red squiggly underline is under something that's clearly correct, like `color: red;` in a CSS file, then first check if it really is correct.
+- The phrase "pattern matching" and why it's important: use other code snippets to remind yourself of correct syntax.
+- When you make a change on a file, and then visually when you refresh your page you don't see any changes, run through a quick checklist:
+    - Did you save? this kills me every time (see: add autosave to VS Code lesson if it's not already there).
+    - Make a temporary, very obvious change on your HTML page. I write some text in the top of the body or a prominent heading. save the file and reload the browser. verify that you see the text. if you don't see the new text, maybe you have the wrong file open, or the file didn't save, or something else very strange is happening.
+    - Make a temporary, very obvious change to your CSS file. I like to add `color: red;` to something extremely obvious like `body` or `h1`. Save and reload the browser and verify that the thing you expected to turn red actually turns red. If it doesn't, maybe the CSS file isn't getting loaded properly. or check for syntax errors earlier in your CSS file that may render the rest of your CSS file inoperable. Are you missing a semicolon? did you use `=` instead of `:` accidentally? are you missing a quotation mark in a font declaration, so your CSS file thinks there's a really long string somewhere? are your curly braces correctly matched and closed?
 
 ### Common Mistakes / Misconceptions
 


### PR DESCRIPTION
Add general tips in the lesson section of debugging.md file and also fixes some typo errors.
Issue Fixed: #814 