### PR TITLE
Remove unnecessary and outdated Express JS video

### DIFF
--- a/express-js/express.md
+++ b/express-js/express.md
@@ -50,7 +50,6 @@ Apprentices can expand their skills in Express.js by finding tutorials online sh
 Apprentices can create a list, in their own words, of the steps they went through during the lab exercise to create a basic Express.js web app. They will refer to this list in future Techtonica and personal projects.
 
 ### Supplemental Materials
-- [Intro video series on Express.js](https://www.youtube.com/playlist?list=PLVHlCYNvnqYpQXeTEA0PxH1spth-K9ey7)
-- [Express.js Tutorial (Level 1)](https://www.youtube.com/watch?v=IjXAr5CJ2Ec)
+- [Intro video series on Express.js](https://www.youtube.com/watch?v=L6_CoHNSbwc&list=PLVHlCYNvnqYpQXeTEA0PxH1spth-K9ey7&index=2&t=0s)
 - [Express.js Tutorial: Build RESTful APIs with Node.js & Express.js ](https://www.youtube.com/watch?v=pKd0Rpw7O48)
 


### PR DESCRIPTION
I removed the video that I believe it's outdated and unnecessary for the Express js curriculum. I linked the "Intro video series on Express.js" directly to the playlist's first video. This playlist about the intro of express is enough, and the "Express.js Tutorial (Level 1)" is not necessary.
Related Issue: https://github.com/Techtonica/curriculum/issues/960