### PR TITLE
Fix link to Github Collaboration Study Material

### DIFF
--- a/github-collaboration/github-collaboration.md
+++ b/github-collaboration/github-collaboration.md
@@ -44,7 +44,7 @@ If you have checked a repository before, you might have noticed it says Branch: 
 - [GitHub Guides](https://guides.github.com/)
 
 ### Lesson
-- [Github Collaboration Guide](https://www.freecodecamp.org/news/how-to-delete-a-git-branch-both-locally-and-remotely/)
+- [Github Collaboration Guide](https://medium.com/@jonathanmines/the-ultimate-github-collaboration-guide-df816e98fb67)
 - [GitHub collaboration (video walkthrough of slides)](https://drive.google.com/open?id=1qTURZrzNXXhqLCQIe_lV8CAkWNpP62kY)
 - [GitHub collaboration (slides)](https://docs.google.com/presentation/d/1dGsFDog3uUq0XwVMCbYRJucPuzBWTFCawdas2r6fBdA/edit#slide=id.p)
 


### PR DESCRIPTION
The previous link was incorrect. Fixed the error and added the right link