### PR TITLE
Added Twilio HTTP headers article

### DIFF
--- a/security/web-security.md
+++ b/security/web-security.md
@@ -101,6 +101,7 @@ In simple words:
 
 ### Further Reading/Practice (for the super interested and more experienced!)
 
+- [HTTP Headers for the Responsible Developer](https://www.twilio.com/blog/a-http-headers-for-the-responsible-developer)
 - [Bug Bounty Programs](https://www.bugcrowd.com/bug-bounty-list/)
 - [Types of Hackers](https://www.cybrary.it/0p3n/types-of-hackers/)
 - OWASP releases a regular list of the [top 10 most critical web application security risks](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project).


### PR DESCRIPTION
Issue no. #1133 

In the Web Security lesson, I found the **Further Reading/Practice** section to be suitable for sharing the Twilio HTTP headers article. So, I have added the relevant link under this section. If there is some change that needs to be made please let me know. Thanks. 