### PR TITLE
Closes issue #1201 outline for code liniting + eslint instructions 

### DIFF
--- a/javascript/eslint.md
+++ b/javascript/eslint.md
@@ -1,0 +1,139 @@
+
+# Code liniting + ESLint Instructions
+
+### Projected Time
+30 minutes
+
+- Lesson: 15-20 min
+- Guided Practice: 5 -10 min (Mock Project)
+- Independed Practice: (Implement it with your projects)
+- Check for Understanding: 1 min
+
+### Prerquisites
+
+Here are topics you must be comfortable with to get the maximum benefit out of this topic:
+
+-  [Javascript 6 - Object Literals](https://github.com/Techtonica/curriculum/blob/master/javascript/javascript-6-object-literals.md)
+- [VSCode](https://github.com/Techtonica/curriculum/blob/master/vs-code/vscode.md)
+
+### Motivation
+
+Linting is a process of using a tool to automatically check your code for potential problems. There are several benefits for doing so for your code:
+
+-  **Highlighting potential errors and bad patterns.** Linters can perform advanced checks to uncover possible errors such as duplicate variables, unreachable code or invalid regular expressions. A warning from the linter will allow you to fix the errors before they even try to run the code.
+-  **Keeping your code style consistent.** It allow you to check you code style for issues like spacing, indentation and placement of braces. Once your team agrees on the coding style, linter can be configured accordingly and checked automatically.
+-  **Enforcing quality.** Well run projects have clear consistent coding conventions, with automated enforcement.If a linting tool is wired into your build process, you may simply prevent the project from starting or being committed into your repository if there are unfixed errors.
+-  **Time saving** At the end it'll only save your time from searching silly bugs and waiting for your Pull Request to be merged due to lack of inconsistency in code style.
+
+### Objectives
+
+**Participants will be able to:**
+
+- Use ESLint seemlessly in their project
+- Integrate ESLint with vscode
+- Use popular style guide suggested by Airbnb
+  
+
+### Specific Things To Learn
+
+- Installation of ESLint
+- Configuration process
+
+### Materials
+
+-  [Improve Your Code With ESLint + VsCode + Airbnb Styleguide](https://www.youtube.com/watch?v=mfGkKlMDfwQ&t=253s) - Colt Steele
+-  [ESLint Quickstart - find errors automatically](https://www.youtube.com/watch?v=qhuFviJn-es) - freeCodeCamp.org
+-  [ESLint + Prettier + VS Code — The Perfect Setup](https://www.youtube.com/watch?v=lHAeK8t94as) - Web Bos
+
+
+### Lesson
+
+ESLint is a tool for identifying and reporting on patterns found in ECMAScript/JavaScript code. In many ways, it is similar to JSLint and JSHint with a few exceptions like ESLint is completely pluggable, every single rule is a plugin and you can add more at runtime.
+
+
+Let's get started with installing ESLint in your project.
+
+To install ESLint all you need to do is run the given command from the inside of your project folder. Installing ESLint globally is an option, but every project should have information about it's dependencies to make sure that every developer working on the project is using the same tools.
+  
+- To install ESLint for specific project:
+
+```
+$ npm install eslint --save-dev
+```
+
+- To install ESLint globally:
+
+```
+$ npm install eslint -g
+```
+
+Once ESLint is installed in the project, need to configure it according to our needs. This can be done in two ways:
+
+
+- Conveniently by running ESLint with the `--init` flag:
+
+```
+$ npx eslint --init
+```
+
+- This will make the process of ESLint setup a bit easier for you by asking a few questions which you can answer according to your team's requirement.
+
+- It'll offer you three ways to configure ESLint for your project:
+	- Choosing **Answer questions about your style** will require you to answer some questions about your project setup, such as which environment are you targeting, ECMAScript version, modules, usage of CommonJS or JSX and some styling preferences. This is a quick way to set up a project with a minimal set of recommended rules.
+	- Choosing **Use a popular style guide** will allow you to base your configuration on one of the popular styles guides from Google, Airbnb and others. This option works well of you already follow or plan to base yours on one of these styleguides
+	- Choosing **Inspect your JavaScript file(s)** will try to derive the linting rules from your existing code base. Works well when you already have an existing code base which you wouldn’t want to change.
+
+- If you have highly opinionated style of code and want to configure ESLint according to yourself:
+- Run the following command to create ESLint config file:
+
+```
+$ eslint --init
+```
+
+- A new file `.eslintrc` will be created with some boiler-plate configuration.
+- You can turn [rules](https://eslint.org/docs/rules/) in ESLint "off", "warn" or "error":
+
+	- "off" or 0 - turn the rule off
+	- "warn" or 1 - turn the rule on as a warning (doesn't affect exit code)
+	- "error" or 2 - turn the rule on as an error (exit code will be 1)
+
+refer Official Documentation for more provided in Suppliment Materials
+
+After configuring ESLint for the project, try to run eslint on your project files by running the command:
+
+```
+$ eslint *.js
+```
+
+To avoid repeatedly typing this into the terminal, save it as an npm script. Open `package.json` and add another script `"lint": "eslint *.js"` to it.
+
+```
+"scripts": {
+	"lint": "eslint *.js"
+},
+```
+
+Now you are good to go with an npm script for linting:
+```
+$ npm run lint
+```
+
+### Integration
+
+This can't be any easier regardless of which Text-Editor/ IDE you are using. Installing a signle plug-in is all you need to do. ESLint is so widely accepted that most of the popular Text-Editor and IDE offer a dedicated plugin for it.
+
+  
+Here are few links to follow:
+
+-  [VS-Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+-  [Sublime Text 3](https://github.com/SublimeLinter/SublimeLinter-eslint)
+-  [Brackets](https://github.com/brackets-userland/brackets-eslint)
+-  [IntelliJ IDEA,bWebStorm, AppCode, AndroidStudio](https://plugins.jetbrains.com/plugin/7494-eslint)
+
+For more information on integration refer the **Integrations** link provided in Supplemental Materials
+
+### Supplemental Materials
+
+-  [Getting Started with ESLint](https://eslint.org/docs/user-guide/getting-started)
+-  [Configuring ESLint](https://eslint.org/docs/user-guide/configuring#top)
+-  [Integrations](https://eslint.org/docs/user-guide/integrations)

--- a/linting/code-linting-eslint.md
+++ b/linting/code-linting-eslint.md
@@ -1,23 +1,143 @@
-# Code liniting + es-lint Instructions
+
+# Code liniting + ESLint Instructions
 
 ### Projected Time
-
 10-15 minutes
+
 - Lesson: 5-7 min
 - Guided Practice: 5 min (Mock Project)
 - Independed Practice: (Implement it with your projects)
 - Check for Understanding: 1 min
 
 ### Prerquisites
+
 Here are topics you must be comfortable with to get the maximum benefit out of this topic:
 
-- [JavaScript](https://github.com/Techtonica/curriculum/blob/master/javascript/javascript-1.md)
-- A project to follow along
+-  [JavaScript](https://github.com/Techtonica/curriculum/blob/master/javascript/javascript-1.md)
+- A project to follow along ([Node.js](https://nodejs.org/en/) (^8.10.0, ^10.13.0, or >=11.10.1))
 
-### Motivation 
+### Motivation
 
-Linting is  a process of using a tool to automatically check your code for potential problems. There are several benefits for doing so for your code:
-- **Highlighting potential errors and bad patterns.** Linters can perform advanced checks to uncover possible errors such as duplicate variables, unreachable code or invalid regular expressions. A warning from the linter will allow you to fix the errors before they even try to run the code.
-- **Keeping your code style consistent.** It allow you to check you code style for issues like spacing, indentation and placement of braces. Once your team agrees on the coding style, linter can be configured accordingly and checked automatically.
-- **Enforcing quality.** Well run projects have clear consistent coding conventions, with automated enforcement.If a linting tool is wired into your build process, you may simply prevent the project from starting or being committed into your repository if there are unfixed errors.
-- **Time saving** At the end it'll only save your time from searching silly bugs and waiting for your Pull Request to be merged due to lack of inconsistency in code styly.
+Linting is a process of using a tool to automatically check your code for potential problems. There are several benefits for doing so for your code:
+
+-  **Highlighting potential errors and bad patterns.** Linters can perform advanced checks to uncover possible errors such as duplicate variables, unreachable code or invalid regular expressions. A warning from the linter will allow you to fix the errors before they even try to run the code.
+-  **Keeping your code style consistent.** It allow you to check you code style for issues like spacing, indentation and placement of braces. Once your team agrees on the coding style, linter can be configured accordingly and checked automatically.
+-  **Enforcing quality.** Well run projects have clear consistent coding conventions, with automated enforcement.If a linting tool is wired into your build process, you may simply prevent the project from starting or being committed into your repository if there are unfixed errors.
+-  **Time saving** At the end it'll only save your time from searching silly bugs and waiting for your Pull Request to be merged due to lack of inconsistency in code style.
+
+### Objectives
+
+**Participants will be able to:**
+
+- Use ESLint seemlessly in their project
+- Integrate ESLint with vscode
+- Use popular style guide suggested by Airbnb
+  
+
+### Specific Things To Learn
+
+- Installation of ESLint
+- Configuration process
+
+### Materials
+
+-  [Improve Your Code With ESLint + VsCode + Airbnb Styleguide](https://www.youtube.com/watch?v=mfGkKlMDfwQ&t=253s) - Colt Steele
+-  [ESLint Quickstart - find errors automatically](https://www.youtube.com/watch?v=qhuFviJn-es) - freeCodeCamp.org
+-  [ESLint + Prettier + VS Code — The Perfect Setup](https://www.youtube.com/watch?v=lHAeK8t94as) - Web Bos
+
+
+### Lesson
+
+ESLint is a tool for identifying and reporting on patterns found in ECMAScript/JavaScript code. In many ways, it is similar to JSLint and JSHint with a few exceptions:
+
+- ESLint uses Espree for JavaScript parsing. 
+- ESLint uses an AST to evaluate patterns in code.
+- ESLint is completely pluggable, every single rule is a plugin and you can add more at runtime.
+
+
+Let's get started with installing ESLint in your project.
+
+To install ESLint all you need to do is run the given command from the inside of your project folder. Installing ESLint globally is an option, but every project should have information about it's dependencies to make sure that every developer working on the project is using the same tools.
+  
+- To install ESLint for specific project:
+
+```
+$ npm install eslint --save-dev
+```
+
+- To install ESLint globally:
+
+```
+$ npm install eslint -g
+```
+
+Once ESLint is installed in the project, need to configure it according to our needs. This can be done in two ways:
+
+
+- Conveniently by running ESLint with the `--init` flag:
+
+```
+$ npx eslint --init
+```
+
+- This will make the process of ESLint setup a bit easier for you by asking a few questions which you can answer according to your team's requirement.
+
+- It'll offer you three ways to configure ESLint for your project:
+	- Choosing **Answer questions about your style** will require you to answer some questions about your project setup, such as which environment are you targeting, ECMAScript version, modules, usage of CommonJS or JSX and some styling preferences. This is a quick way to set up a project with a minimal set of recommended rules.
+	- Choosing **Use a popular style guide** will allow you to base your configuration on one of the popular styles guides from Google, Airbnb and others. This option works well of you already follow or plan to base yours on one of these styleguides
+	- Choosing **Inspect your JavaScript file(s)** will try to derive the linting rules from your existing code base. Works well when you already have an existing code base which you wouldn’t want to change.
+
+- If you have highly opinionated style of code and want to configure ESLint according to yourself:
+- Run the following command to create ESLint config file:
+
+```
+$ eslint --init
+```
+
+- A new file `.eslintrc` will be created with some boiler-plate configuration.
+- You can turn [rules](https://eslint.org/docs/rules/) in ESLint "off", "warn" or "error":
+
+	- "off" or 0 - turn the rule off
+	- "warn" or 1 - turn the rule on as a warning (doesn't affect exit code)
+	- "error" or 2 - turn the rule on as an error (exit code will be 1)
+
+refer Official Documentation for more provided in Suppliment Materials
+
+After configuring ESLint for the project, try to run eslint on your project files by running the command:
+
+```
+$ eslint *.js
+```
+
+To avoid repeatedly typing this into the terminal, save it as an npm script. Open `package.json` and add another script `"lint": "eslint *.js"` to it.
+
+```
+"scripts": {
+	"lint": "eslint *.js"
+},
+```
+
+Now you are good to go with an npm script for linting:
+```
+$ npm run lint
+```
+
+### Integration
+
+This can't be any easier regardless of which Text-Editor/ IDE you are using. Installing a signle plug-in is all you need to do. ESLint is so widely accepted that most of the popular Text-Editor and IDE offer a dedicated plugin for it.
+
+  
+Here are few links to follow:
+
+-  [VS-Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+-  [Sublime Text 3](https://github.com/SublimeLinter/SublimeLinter-eslint)
+-  [Brackets](https://github.com/brackets-userland/brackets-eslint)
+-  [IntelliJ IDEA,bWebStorm, AppCode, AndroidStudio](https://plugins.jetbrains.com/plugin/7494-eslint)
+
+For more information on integration refer the **Integrations** link provided in Supplemental Materials
+
+### Supplemental Materials
+
+-  [Getting Started with ESLint](https://eslint.org/docs/user-guide/getting-started)
+-  [Configuring ESLint](https://eslint.org/docs/user-guide/configuring#top)
+-  [Integrations](https://eslint.org/docs/user-guide/integrations)

--- a/linting/code-linting-eslint.md
+++ b/linting/code-linting-eslint.md
@@ -1,0 +1,23 @@
+# Code liniting + es-lint Instructions
+
+### Projected Time
+
+10-15 minutes
+- Lesson: 5-7 min
+- Guided Practice: 5 min (Mock Project)
+- Independed Practice: (Implement it with your projects)
+- Check for Understanding: 1 min
+
+### Prerquisites
+Here are topics you must be comfortable with to get the maximum benefit out of this topic:
+
+- [JavaScript](https://github.com/Techtonica/curriculum/blob/master/javascript/javascript-1.md)
+- A project to follow along
+
+### Motivation 
+
+Linting is  a process of using a tool to automatically check your code for potential problems. There are several benefits for doing so for your code:
+- **Highlighting potential errors and bad patterns.** Linters can perform advanced checks to uncover possible errors such as duplicate variables, unreachable code or invalid regular expressions. A warning from the linter will allow you to fix the errors before they even try to run the code.
+- **Keeping your code style consistent.** It allow you to check you code style for issues like spacing, indentation and placement of braces. Once your team agrees on the coding style, linter can be configured accordingly and checked automatically.
+- **Enforcing quality.** Well run projects have clear consistent coding conventions, with automated enforcement.If a linting tool is wired into your build process, you may simply prevent the project from starting or being committed into your repository if there are unfixed errors.
+- **Time saving** At the end it'll only save your time from searching silly bugs and waiting for your Pull Request to be merged due to lack of inconsistency in code styly.


### PR DESCRIPTION
Fixes #1201 Add outline for code liniting + eslint instructions

I've compiled a markdown `code-linting-eslint.md` with appropriate amount of instructions and resources for the topic. I wasn't able to figure out where to put it so i created `./linting` directory in root and here's my PR. Please have look and share your valuable feedback