### PR TITLE
Replaced codeacademy pro link 'Understanding Promises' for issue #1115

### DIFF
--- a/javascript/javascript-9.md
+++ b/javascript/javascript-9.md
@@ -126,7 +126,7 @@ askMom();
 
 ### Supplemental Materials
 - [Using Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
-- [Understanding Promises](https://www.codecademy.com/courses/asynchronous-javascript/lessons/promises/exercises/understanding-promises)
+- [JavaScript Promises for dummies](https://scotch.io/tutorials/javascript-promises-for-dummies)
 - [JavaScript Promises in 10 Minutes](https://www.youtube.com/watch?v=DHvZLI7Db8E)
 - [Async/await reference](https://javascript.info/async-await)
 - [Introduction to Promises](https://beta.observablehq.com/@mbostock/introduction-to-promises)


### PR DESCRIPTION
Replaced CodeAcademy Pro link 'Understanding  Promises' with a comprehensive free 'JavaScript Promises for dummies' article from scotch.io  
Fixes #1115 