### PR TITLE
Make instructions more explicit, remove ambiguity of 1 or 2 buttons

### DIFF
--- a/projects/eventonica/eventonica-part4-apis.md
+++ b/projects/eventonica/eventonica-part4-apis.md
@@ -3,7 +3,7 @@
 ### Overview
 Now that you've learned about APIs, AJAX, and JSON, you'll extend your Eventonica project to make API calls to the Ticketmaster API and display the results in the UI.
 
-In this part of the project, you'll add the ability to import events from Ticketmaster. A user of your site will be able to search for events by keyword, then choose an event and add it to the array of Events.
+In this part of the project, you'll add the ability to import events from Ticketmaster. A user of your site will be able to search for events by keyword, then choose an event and add it to their list of events.
 
 ### Instructions
 
@@ -15,17 +15,22 @@ Before doing anything else, create a new folder called Eventonica-Part-4 and cop
 
 1. Read the [Ticketmaster API docs](https://developer.ticketmaster.com/products-and-docs/apis/discovery-api/v2/) to learn about their APIs overall and the Event Search API specifically. You don't need to read the docs for the other APIs offered.
 
-2. Try out the [Ticketmaster API Explorer](https://developer.ticketmaster.com/api-explorer/v2/) to practice using the Event Search API. Try searching for events by keyword. 
+2. Try out the [Ticketmaster API Explorer](https://developer.ticketmaster.com/api-explorer/v2/) to practice using the Event Search API. Try searching for events by keyword.
 
-2. Decide where in your HTML you want to incorporate the Ticketmaster API. Add the following to your HTML:
- - The header "Import Events from Ticketmaster". 
- - A search box for event keyword
- - Somewhere to display the results
- - A button that says "Import first event from Ticketmaster"
+3. Decide where in your HTML you want to incorporate the Ticketmaster API, and add the following to your HTML file:
+ - The header "Import Events from Ticketmaster"
+ - A search box for an event keyword and a submit button
+ - An area to display the results
 
-3. In your jQuery code, add code so that when a user submits a keyword in the new form, you call the Ticketmaster API and search for events with that keyword, and use jQuery to display the results on the page.
+4. In your jQuery file, add code so that when a user submits a keyword in your new HTML form:
+ - You call the Ticketmaster API and search for events using that keyword as a query
+ - You use jQuery to display the results on the page in the area you designated in step 3
 
-4. Add jQuery code so that when the user clicks the "Import first event from Ticketmaster" button, a new Event is created (and added to the array of Events) using the data from the first item in the array of events queried from Ticketmaster. Note: Ticketmaster will not return exactly the same fields as your Event class has. Explore the Ticketmaster API docs and responses to find the most appropriate data from the API response to use to create the new Event instance. 
+5. Now you will allow the user to import the first returned event:
+ - Add a button in your HTML file that is labeled "Import first event from Ticketmaster"
+ - Add jQuery code so that when the user clicks the "Import first event from Ticketmaster" button, a new Event is created and added to the array of Events you generated using the EventRecommender class
+ - To do this, use the data in the first item from the array of events returned from the Ticketmaster API in the previous step. Note: Ticketmaster will not return exactly the same fields as your Event class has. Explore the Ticketmaster API docs and responses to find the most appropriate data from the API response to use to create the new Event instance.
+ - Display that first returned event in the User's saved events section you coded in the previous exercises
 
 ### Challenges
 Try doing at least one of the extensions below:


### PR DESCRIPTION
Talked to Bill before sending. For eventonica-part-4, I tried to clarify the instructions, as I saw some apprentices struggling with listing all events retrieved by the ticketmaster API, and then adding the first event. Therefore, I tried to split the two objectives a little more cleanly and make the steps a little more explicit. Please check that I also understood the objectives correctly. 