### PR TITLE
fix: add homebrew installation steps

### DIFF
--- a/dev-tools/command-line-advanced.md
+++ b/dev-tools/command-line-advanced.md
@@ -285,14 +285,11 @@ Before getting started, check that the following requirements are fullfilled:
 
 Then, installation will take three steps:
 1. Open a macOS Terminal or Linux shell prompt.
-2. Run the install script by pasting :
+2. Run the install script :
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
-3. Verify your installation by checking its version: 
- ```
- brew --version
-```
+3. Verify your installation checking its version: `brew --version`. If no errors appear, everything went perfectly.
 For further details, visit [Homebrew installation page](https://docs.brew.sh/Installation).
 
 #### Applications
@@ -301,9 +298,7 @@ Now that it's installed, prompt can be used to manage the packages we need:
 ```
 brew install package-name
 ```
-And `package-name` can be any package from the [listing](https://formulae.brew.sh/formula/) that Homebrew provides. Let's see an example of how to install `wget`:
-
-```brew install wget```
+And `package-name` can be any package from the [listing](https://formulae.brew.sh/formula/) that Homebrew provides. Let's see an example of how to install `wget`: `brew install wget`
 
 After that, to check that it has been properly installed, we can verify that the version of the package installed matches with the one provided in the [listing](https://formulae.brew.sh/formula/).
 ```

--- a/dev-tools/command-line-advanced.md
+++ b/dev-tools/command-line-advanced.md
@@ -2,11 +2,11 @@
 
 ### Projected Time
 
-About 1 hour
+About 1 hour and 20 minutes
 
 - 20 minutes for Lesson
-- 20 minutes for Guided Practice
-- 15 minutes for Independent Practice
+- 30 minutes for Guided Practice
+- 20 minutes for Independent Practice
 - 10 minutes for Check for Understanding
 
 ### Prerequisites
@@ -271,6 +271,45 @@ This lesson helps you create an executable script. It will read information from
 
 Greg's Wiki is full of common mistakes (e.g. [why you shouldn't parse ls](http://mywiki.wooledge.org/ParsingLs)).
 
+### Installing Homebrew
+
+Now you know how to move using your command line, let's get deep into [Homebrew](https://brew.sh/). It's a package manager for masOS or Linux which provides a simple way to install programs or tools, similar to an app store for CLI.
+
+Before getting started, check that the following requirements are fullfilled:
+|macOS   |Linux   |
+|------------------|-------------|
+|**64-bit Intel** CPU | **64-bit x86_64** CPU |
+| Compatible shell (`.bash` or **zsh**)|  **GCC** 4.7.0 or newer  |
+|**macOS** 10.13 or newer|**Linux** 2.6.32 or newer|
+|Command Line Tools for [Xcode](https://apps.apple.com/us/app/xcode/id497799835)|**Glibc** 2.13 or newer|
+
+Then, installation will take three steps:
+1. Open a macOS Terminal or Linux shell prompt.
+2. Run the install script by pasting :
+```
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
+3. Verify your installation by checking its version: 
+ ```
+ brew --version
+```
+For further details, visit [Homebrew installation page](https://docs.brew.sh/Installation).
+
+#### Applications
+
+Now that it's installed, prompt can be used to manage the packages we need:
+```
+brew install package-name
+```
+And `package-name` can be any package from the [listing](https://formulae.brew.sh/formula/) that Homebrew provides. Let's see an example of how to install `wget`:
+
+```brew install wget```
+
+After that, to check that it has been properly installed, we can verify that the version of the package installed matches with the one provided in the [listing](https://formulae.brew.sh/formula/).
+```
+wget --version
+```
+
 ### Independent Practice
 
 Spend 15 minutes checking out these materials:
@@ -278,6 +317,9 @@ Spend 15 minutes checking out these materials:
 - [BashGuide](http://mywiki.wooledge.org/BashGuide)
 - [Filenames and Pathnames in Shell: How to do it Correctly](https://www.dwheeler.com/essays/filenames-in-shell.html)
 - [I/O Redirection](http://wiki.bash-hackers.org/syntax/redirection)
+
+### Challenge with Homebrew
+Try to install other optional utility using Homebrew, for example  `tree` .
 
 ### Challenge with `Awk` Command
 
@@ -328,3 +370,4 @@ Then try this hacker rank problem: [Sed challenge #1](https://www.hackerrank.com
 - How do you redirect input and output streams?
 - How do do you find the commands you have used before?
 - How do you modify the command prompt info?
+- How do you install a new package with Homebrew?

--- a/dev-tools/command-line-advanced.md
+++ b/dev-tools/command-line-advanced.md
@@ -291,6 +291,7 @@ Then, installation will take three steps:
 ```
 3. Verify your installation checking its version: `brew --version`. If no errors appear, everything went perfectly.
 For further details, visit [Homebrew installation page](https://docs.brew.sh/Installation).
+4. Finally, run `brew doctor` which will check your system for potential problems.
 
 #### Applications
 

--- a/git/git-version-control.md
+++ b/git/git-version-control.md
@@ -13,7 +13,8 @@ About 2.5 hours
 
 ### Prerequisites
 
-- [Command Line Interface lesson](/command-line/command-line-interface.md)
+- [Command Line Interface lesson](/dev-tools/command-line-interface.md)
+- [Command Line Advanced lesson](/dev-tools/command-line-advanced.md)
 - [Shell Commands lesson](https://docs.google.com/presentation/d/1LuOLcpSAtNQlbULx9nWgXJNhgWQlfQ4nzLWQ0DuuPQk/edit?usp=sharing)
 
 ### Learning styles represented
@@ -100,7 +101,10 @@ _Imagine you are coloring on a flower coloring book. You colored in green for al
 
 Techtonica staff will assign pairs. Go through the following steps on one pair partner's computer first, then go through all the steps again the other pair partner's computer. The repetition of doing this twice will help solidify the new concepts.
 
-1. Launch your Terminal and run `git --version`. If a version number appears, you already have git installed. If a version number does not appear, run `git` and follow the prompts to install Git.
+1. Launch your Terminal and run `git --version`. If a version number appears, you already have git installed. If a version number does not appear:
+   - Install `git` via Homebrew:  `brew install git`
+> If Homebrew isn't install, check out [Command Line Advanced lesson](/dev-tools/command-line-advanced.md).
+   - Or run `git` and follow the prompts to install Git.
 
 2. Using the Terminal, navigate to the Desktop.
 

--- a/node-js/node-lab-exercise-part-1.md
+++ b/node-js/node-lab-exercise-part-1.md
@@ -54,14 +54,24 @@ Visit the [nvm repository on GitHub](https://github.com/creationix/nvm) to get s
 
 Follow the installation steps in nvm's readme. Most importantly, these steps:
 
-1. Execute the [install script](https://github.com/creationix/nvm#install-script) using cURL.
-   - Pay attention to the end of the install script because it'll say if it installed nvm's startup scripts in your `.bash_profile`, your `.profile`, or your `.bashrc`. You'll need this information if you need to troubleshoot your installation.
-2. [Verify your nvm installation](https://github.com/creationix/nvm#verify-installation) by typing `command -v nvm` in your terminal. You should just see the output `nvm` in your terminal. (See their readme to read about why `which nvm` does not work. Do not be alarmed that `which nvm` returns nothing!)
+1. Install nvm via Homebrew: `brew install nvm`
+
+2. Create a system directory for nvm: `mkdir ~/.nvm`
+
+3. Open your `.bash_profile`, `.profile`, `.zshrc` or `.bashrc` file and append the following lines:
+```
+# NVM
+export NVM_DIR=~/.nvm
+source $(brew --prefix nvm)/nvm.sh
+```
+   - This will update your path, so remember to reset your Terminal after this step.
+
+4. [Verify your nvm installation](https://github.com/creationix/nvm#verify-installation) by typing `command -v nvm` in your terminal. You should just see the output `nvm` in your terminal. (See their readme to read about why `which nvm` does not work. Do not be alarmed that `which nvm` returns nothing!)
    - If `command -v nvm` did not work, there's a note that may help you in the Install section of nvm's readme. It starts with the text "Note: On OS X, if you get nvm: command not found after running the install script, one of the following might be the reason:" -- try those. Usually it has to do with where the nvm install script put the script that sources nvm for you every time you start your terminal.
-3. [Download the latest version of node](https://github.com/creationix/nvm#usage) using the command `nvm install node` (see their readme for more information about how to download specific versions of node).
-4. Type `nvm use node` in your terminal. This makes you use this version of node you just downloaded!
+5. [Download the latest version of node](https://github.com/creationix/nvm#usage) using the command `nvm install node` (see their readme for more information about how to download specific versions of node).
+6. Type `nvm use node` in your terminal. This makes you use this version of node you just downloaded!
    - If you had previously installed node on your system, don't worry: it's still on your machine and accessible via `nvm use system`.
-5. When you type `which node`, you should see a long path including a new `.nvm` hidden directory inside your home directory.
+7. When you type `which node`, you should see a long path including a new `.nvm` hidden directory inside your home directory.
 
 ---
 

--- a/node-js/node-lab-exercise-part-1.md
+++ b/node-js/node-lab-exercise-part-1.md
@@ -55,9 +55,7 @@ Visit the [nvm repository on GitHub](https://github.com/creationix/nvm) to get s
 Follow the installation steps in nvm's readme. Most importantly, these steps:
 
 1. Install nvm via Homebrew: `brew install nvm`
-
 2. Create a system directory for nvm: `mkdir ~/.nvm`
-
 3. Open your `.bash_profile`, `.profile`, `.zshrc` or `.bashrc` file and append the following lines:
 ```
 # NVM
@@ -65,7 +63,6 @@ export NVM_DIR=~/.nvm
 source $(brew --prefix nvm)/nvm.sh
 ```
    - This will update your path, so remember to reset your Terminal after this step.
-
 4. [Verify your nvm installation](https://github.com/creationix/nvm#verify-installation) by typing `command -v nvm` in your terminal. You should just see the output `nvm` in your terminal. (See their readme to read about why `which nvm` does not work. Do not be alarmed that `which nvm` returns nothing!)
    - If `command -v nvm` did not work, there's a note that may help you in the Install section of nvm's readme. It starts with the text "Note: On OS X, if you get nvm: command not found after running the install script, one of the following might be the reason:" -- try those. Usually it has to do with where the nvm install script put the script that sources nvm for you every time you start your terminal.
 5. [Download the latest version of node](https://github.com/creationix/nvm#usage) using the command `nvm install node` (see their readme for more information about how to download specific versions of node).

--- a/node-js/node-lab-exercise-part-1.md
+++ b/node-js/node-lab-exercise-part-1.md
@@ -56,7 +56,7 @@ Follow the installation steps in nvm's readme. Most importantly, these steps:
 
 1. Install nvm via Homebrew: `brew install nvm`
 2. Create a system directory for nvm: `mkdir ~/.nvm`
-3. Open your `.bash_profile`, `.profile`, `.zshrc` or `.bashrc` file and append the following lines:
+3. Open your `.zshrc` file and append the following lines:
 ```
 # NVM
 export NVM_DIR=~/.nvm


### PR DESCRIPTION
Closes Issue #1155 - Add homebrew to Advanced Command Line

1. Change dead link for Advanced command line, since it migrated from `../command-line/command-line-advanced.md` to `../dev-tools/command-line-advanced.md`.
2. Create a new section inside [Advanced Command Line](https://github.com/Techtonica/curriculum/blob/master/dev-tools/command-line-advanced.md) lesson about Homebrew which contains:
   - what it is 
   - how to install it
   - guide practice to install an optional tool -> `wget`
   - challenge to install other optional tool -> `tree`
3. Update installation for [git](https://github.com/Techtonica/curriculum/blame/master/git/git-version-control.md#L103) and [nvm](https://github.com/Techtonica/curriculum/blame/master/node-js/node-lab-exercise-part-1.md#L57) using Homebrew
