### PR TITLE
Fix links in Deploying to Heroku outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Apprentices should memorize [**this**](Cheatsheet.md) within the first month.
 
 ### Week 9 - PERN Mini-Project (Postgres+Express+React+Node)
 
-1. [Deploying to Heroku with React and Node](/deploying/deploying.md)
+1. [Deploying to Heroku with React and Node](/deploying/deploying-to-heroku.md)
 1. [Optimizing your React/NodeJS Project](/optimization/optimizing-your-react-node-project.md)
 1. [Enzyme Testing](/testing-and-tdd/enzyme-testing.md)
 

--- a/deploying/deploying-to-heroku.md
+++ b/deploying/deploying-to-heroku.md
@@ -12,6 +12,7 @@ About 3-4.5 hours
 - [Node](../node-js/node-js.md)
 - [Express](../express-js/express.md)
 - [PostgreSQL](../databases/installing-postgresql.md)
+- [A free Heroku account](https://signup.heroku.com/dc)
 
 ### Motivation
 

--- a/node-js/node-js.md
+++ b/node-js/node-js.md
@@ -46,7 +46,6 @@ Participants should take turns in their pairs reading through and interpreting t
 - Be aware of how to find [Node's API docs](https://nodejs.org/api/), and briefly familiarize yourself with its structure. You don't need to read it all now!
 - Be aware that one way to install Node is by [downloading it directly from their website](https://nodejs.org/en/). However, we are not using this method; we're using nvm.
 - [The beginner's guide: Understanding Node.js & Express.js fundamentals](https://medium.com/@LindaVivah/the-beginners-guide-understanding-node-js-express-js-fundamentals-e15493462be1)
-- [Why use Node.js? (video)](https://www.youtube.com/watch?v=zy8IOlIg3aw) Note: this is a different video than above
 - [Why learn Node.js? (video)](https://www.youtube.com/watch?v=mCC5WGzx9Z8)
 - [8 Reasons to use Node.js (video)](https://www.youtube.com/watch?v=BKorQQO4xtM)
 - [The definitive Node.js handbook](https://medium.freecodecamp.org/the-definitive-node-js-handbook-6912378afc6e)


### PR DESCRIPTION
Should close #1363
- Changed deploying.md file name to deploying-to-heroku.md
- Removed one video link with label "Why use Node.js?" from node-js.md
- Added "A free Heroku account under prerequisites in deploying.md file