### PR TITLE
Change SQLite references to PostgreSQL

### DIFF
--- a/databases/sql.md
+++ b/databases/sql.md
@@ -18,7 +18,7 @@ Most companies use relational databases to store their data.
 
 **Participants will be able to:**
 
-- Interact with SQLite through the command line and through a GUI SQLite browser such as [DB Browser for SQLite](https://sqlitebrowser.org/)
+- Interact with PostgreSQL through the command line
 - Create database tables
 - Add, update, and delete data
 - Query data
@@ -54,18 +54,17 @@ Most companies use relational databases to store their data.
 ### Independent Practice
 
 1. Work through the Codecademy SQL Tutorial: https://www.codecademy.com/learn/learn-sql
-2. SQLite is a version of SQL that comes installed on mac! Try it out:
-   - In Terminal, type `sqlite3` to use SQLite.
+2. PostgreSQL is a popular, open-source version of SQL. Try it out:
+   - In Terminal, type `psql` to use PostgreSQL.
    - Try adding a table with a command like `CREATE TABLE food (name TEXT, calories INTEGER);`
    - See that the table was created by typing `.tables` to see the list of all existing tables.
    - Try adding some data: `INSERT INTO food VALUES ("pizza", 500);`
    - See the data: `SELECT * from food;`
-3. Using SQLite, try creating tables and adding, updating, deleting, and querying data yourself!
-4. Download and install [DB Browser for SQLite](https://sqlitebrowser.org/) via its download page. Try opening the database you just created! Browse the data and get a feel for how to move around
+3. Using PostgreSQL, try creating tables and adding, updating, deleting, and querying data yourself!
 
 ### Challenge
 
-In SQLite on your own machine, you are going to create the tables for a microblogging platform (an app similar to Twitter). Your database should be able to store user information and posts by specific users. One post must _belong to_ exactly one user. One user can have many posts. Later, we'll add the ability for users to follow each other, but not now.
+In PostgreSQL on your own machine, you are going to create the tables for a microblogging platform (an app similar to Twitter). Your database should be able to store user information and posts by specific users. One post must _belong to_ exactly one user. One user can have many posts. Later, we'll add the ability for users to follow each other, but not now.
 
 1. With pencil/pen and paper, write out the data for a database with the following spec. Fill in the fields with fake data that you make up. Be sure to link posts to a certain existing user!
 
@@ -76,7 +75,7 @@ In SQLite on your own machine, you are going to create the tables for a microblo
      - which has an integer field named: `user_id`
      - and a text field named: `content`
 
-2. Use the `sqlite3` command in your terminal to enter the SQLite command line program. Once there, use SQL statements to create two tables according to the spec for the two tables in step 0.
+2. Use the `psql` command in your terminal to enter the PostgreSQL command line program. Once there, use SQL statements to create two tables according to the spec for the two tables in step 0.
 
 3. Once you have your two tables set up, compare your table set up with another apprentice's.
 
@@ -115,7 +114,7 @@ If you complete the above, we'll move on to creating a join table.
 ### Supplemental Materials
 
 - Another good SQL tutorial: [SQL Teaching](https://www.sqlteaching.com)
-- Free SQL Cloud DBs can be created at https://www.elephantsql.com/ (this services uses postgres, not SQLite)
+- Free SQL Cloud DBs can be created at https://www.elephantsql.com/
 - [SQL Codecademy Tutorial (interactive)](https://www.codecademy.com/learn/learn-sql)
 - [DB Browser for SQLite](https://sqlitebrowser.org/)
 - [Khan Academy's introductory SQL(videos)](https://www.khanacademy.org/computing/computer-programming/sql/sql-basics/v/welcome-to-sql)

--- a/databases/sql.md
+++ b/databases/sql.md
@@ -6,7 +6,7 @@ About 3.5-4 hours
 
 ### Prerequisites
 
-- [Data Models](./sql.md)
+- [Data Models](./data-models.md)
 
 ### Motivation
 
@@ -75,11 +75,11 @@ In PostgreSQL on your own machine, you are going to create the tables for a micr
      - which has an integer field named: `user_id`
      - and a text field named: `content`
 
-2. Use the `psql` command in your terminal to enter the PostgreSQL command line program. Once there, use SQL statements to create two tables according to the spec for the two tables in step 0.
+2. Use the `psql` command in your terminal to enter the PostgreSQL command line program. Once there, use SQL statements to create two tables according to the spec for the two tables in step 1.
 
 3. Once you have your two tables set up, compare your table set up with another apprentice's.
 
-4. Add sample data to the tables yourself (make up some users and posts)
+4. Add sample data to the tables yourself (make up some users and posts).
 
 5. Try writing queries that get data such as:
 

--- a/projects/take-home-problems/backend.md
+++ b/projects/take-home-problems/backend.md
@@ -84,7 +84,15 @@ CREATE TABLE permits(
   "Neighborhoods - Analysis Boundaries" TEXT,
   "Supervisor District" TEXT,
   "Zipcode" TEXT,
-  "Location" TEXT
+  "Location" TEXT,
+  "SF Find Neighborhoods" TEXT,
+  "Current Police Districts" TEXT,
+  "Current Supervisor Districts" TEXT,
+  "Analysis Neighborhoods" TEXT,
+  "Current Police Districts (2)" TEXT,
+  "Zip Codes" TEXT,
+  "Fire Prevention Districts" TEXT,
+  "Supervisor Districts (1)" TEXT
 );
 
 CREATE TABLE contacts(
@@ -97,29 +105,44 @@ CREATE TABLE contacts(
   "State" TEXT,
   "Zipcode" TEXT,
   "Phone" TEXT,
-  "Phone2" TEXT
+  "Phone2" TEXT,
+  "License Number" TEXT
 );
 
 CREATE TABLE fire_violations(
-  "Violation Id" TEXT,
-  "Primary" TEXT,
-  "Violation Number" TEXT,
-  "Violation Date" TEXT,
-  "Violation Item" TEXT,
-  "Violation Item Description" TEXT,
-  "Citation Number" TEXT,
-  "Corrective Action" TEXT,
   "Inspection Number" TEXT,
+  "Violation Id" TEXT,
   "Address" TEXT,
-  "Zipcode" TEXT,
   "Battalion" TEXT,
   "Station Area" TEXT,
   "Fire Prevention District" TEXT,
-  "Status" TEXT,
+  "Citation Number" TEXT,
   "Close Date" TEXT,
+  "Corrective Action" TEXT,
+  "Status" TEXT,
+  "Violation Item Description" TEXT,
+  "Violation Date" TEXT,
+  "Violation Number" TEXT,
+  "Violation Item" TEXT,
+  "Primary" TEXT,
+  "Zipcode" TEXT,
+  "Neighborhood District" TEXT,
   "Supervisor District" TEXT,
-  "Neighborhood  District" TEXT,
-  "Location" TEXT
+  "Location" TEXT,
+  "Neighborhoods 2" TEXT,
+  "Supervisor Districts 2" TEXT,
+  "Fire Prevention Districts 2" TEXT,
+  "Current Police Districts 2" TEXT,
+  "Neighborhoods - Analysis Boundaries 2" TEXT,
+  "Zip Codes 2" TEXT,
+  "Neighborhoods (old) 2" TEXT,
+  "Police Districts 2" TEXT,
+  "Central Market/Tenderloin Boundary 2" TEXT,
+  "Central Market/Tenderloin Boundary Polygon - Updated 2" TEXT,
+  "Neighborhoods" TEXT,
+  "SF Find Neighborhoods" TEXT,
+  "Current Police Districts 3" TEXT,
+  "Current Supervisor Districts" TEXT
 );
 ```
 

--- a/projects/take-home-problems/backend.md
+++ b/projects/take-home-problems/backend.md
@@ -43,7 +43,7 @@ The raw data for this problem can be downloaded as CSV files from https://datasf
 - https://data.sfgov.org/Housing-and-Buildings/Electrical-Permits-Contacts/fdm7-jqqf
 - https://data.sfgov.org/Housing-and-Buildings/Fire-Violations/4zuq-2cbe
 
-You can build a sqlite database containing the data set by running the commands below. You're free to modify the database schema however you like or use a different database if you prefer.
+You can build a Postgres database containing the data set by running the commands below. You're free to modify the database schema however you like or use a different database if you prefer.
 
 ### Setup
 
@@ -55,13 +55,13 @@ curl "https://data.sfgov.org/api/views/fdm7-jqqf/rows.csv?accessType=DOWNLOAD" >
 curl "https://data.sfgov.org/api/views/4zuq-2cbe/rows.csv?accessType=DOWNLOAD" > Fire_Violations.csv
 ```
 
-Run sqlite:
+Run Postgres:
 
 ```sh
-sqlite3
+psql
 ```
 
-Within sqlite:
+Within Postgres:
 
 ```sql
 CREATE TABLE permits(
@@ -125,13 +125,10 @@ CREATE TABLE fire_violations(
 
 Import csv:
 
-```
-.mode csv
+```sql
+\COPY permits FROM './Electrical_Permits.csv' (FORMAT CSV, HEADER)
+\COPY contacts FROM './Electrical_Permits_Contacts.csv' (FORMAT CSV, HEADER)
+\COPY fire_violations FROM './Fire_Violations.csv' (FORMAT CSV, HEADER)
 
-.import ./Electrical_Permits.csv permits
-.import ./Electrical_Permits_Contacts.csv contacts
-.import ./Fire_Violations.csv fire_violations
-
-.save ./database.sqlite
-.quit
+quit
 ```


### PR DESCRIPTION
Addresses https://github.com/Techtonica/curriculum/issues/1204 by changing SQLite references and tooling to PostgreSQL.
In Addition:
https://github.com/Techtonica/curriculum/commit/387cf75ff4a8891168d33a709ac96091a3906956 updates the columns for the database to match the CSV pulled from the website in the instructions for backend.md.
https://github.com/Techtonica/curriculum/commit/5dc370e748dbf93dff9aab96568265f63dd8e6f7 fixes a typo in the reference to a previous step and corrects the link to the prereq lesson. 