### PR TITLE
Improve stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,20 +1,28 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 45
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - Epic
-  - pinned
-  - security
-  - internal
-  - priority
-# Label to use when marking an issue as stale
-staleLabel: wontfix
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+pulls:
+  daysUntilStale: 21
+  daysUntilClose: 10
+  onlyLabels:
+    - pending-pr-revisions
+  markComment: >
+    This pull request is pending revisions but has had no activity
+    for 21 days. If no updates are made it will be closed in 10 days.
+    If you need assistance completing the revisions, please reach out
+    to our project maintainers on this pull request. Thanks you for you contribution.
+  staleLabel: "Close to expiring"
+
+issues:
+  daysUntilStale: 90
+  daysUntilClose: 14
+  stateLabel: wontfix
+  exemptProjects: true
+  exemptMilestones: true
+  exemptLabels:
+    - Epic
+    - pinned
+    - internal
+    - priority
+  markComment: >
+    Although it may very well be a good idea, this issue has not had
+    recent activity and is unlikely to be worked on. Consider creating
+    your own pull request for the issue if that is feasible. If no further
+    activity occurs, this will be closed in 14 days. Thank you for your contribution.


### PR DESCRIPTION
  - Use different rules for issues vs pull requests
  - Expand the stale window for issues to 180 days and exclude ones that have been "triaged" by the team and assigned to a milestone or project,  automatically without even needing "pinned" labels
  - For issues, add messaging encouraging them to make their own pull request
 
Config docs: https://github.com/probot/stale#usage