### PR TITLE
Update week 6 assessment topics date to 2021 ver

### DIFF
--- a/objectives/week-6-assessment.md
+++ b/objectives/week-6-assessment.md
@@ -42,7 +42,7 @@
 - RegEx (at least the patterns of creating them, you should still know what they are)
 - CSS/jQuery/HTML
 - No conceptual questions on JavaScript (i.e. no asking what closure is or what Promise is)
-- All topics covered after Monday, 10 February 2020 are not included (e.g. Node, http.server, Express, JSON, REST, etc)
+- All topics covered after Friday, 19 February 2021 are not included (e.g. Node, http.server, Express, JSON, REST, etc)
 
 ## Example Questions
 


### PR DESCRIPTION
Currently it says that any topics covered after Monday February 10, 2020 will not be included. The equivalent date for the 2021 H1 cohort is Friday February 19, 2021.