### PR TITLE
Update "Intro to HTTP" prerequisite link

### DIFF
--- a/api/intro-to-http.md
+++ b/api/intro-to-http.md
@@ -6,7 +6,7 @@ Approximately 2 hours
 
 ### Prerequisites
 
-- [How the Internet Works](/requests-and-response/requests-and-response.md)
+- [How the Internet Works](/networking-computing/how-the-internet-works.md)
 
 ### Motivation
 

--- a/api/intro-to-http.md
+++ b/api/intro-to-http.md
@@ -6,7 +6,7 @@ Approximately 2 hours
 
 ### Prerequisites
 
-- [How the Internet Works](/networking-computing/how-the-internet-works.md)
+- [How the Internet Works](/networking-computing/README.md)
 
 ### Motivation
 


### PR DESCRIPTION
The "How the Internet Works" topic currently points to `requests-and-response.md`, but the file was since renamed to `how-the-internet-works.md` and moved to the `networking-computing` directory