### PR TITLE
Need semicolon after create database

### DIFF
--- a/databases/installing-postgresql.md
+++ b/databases/installing-postgresql.md
@@ -16,9 +16,8 @@
 - This creates a superuser named postgres
 - If you run `psql` with no args, it assumes you want to connect as your current user (`whoami` command output)
 - Run `psql postgres` to connect as the superuser
-- `create database <YOUR_USERNAME>`
+- `create database eventonica`;
 - `\q` to quit
-- Now you can connect with just `psql`
 
 ### Configuration
 


### PR DESCRIPTION
we went over with George.

Also George said that this is bad practice
"Now you can connect with just `psql`" - so maybe we wanna to take this out?

Also George said he doesn't recommend we name the server after our username but to our project - Eventonica