### PR TITLE
Update pre-requisites link

### DIFF
--- a/databases/sql-1.md
+++ b/databases/sql-1.md
@@ -6,7 +6,7 @@ About 3.5-4 hours
 
 ### Prerequisites
 
-- [Data Models](./data-models.md)
+- [Data Modeling Part 1: Single Tables](./data-modeling-1.md)
 
 ### Motivation
 


### PR DESCRIPTION
I made a pull request to update the pre-reqs link to the database modeling part 1 lesson instead of the data models page that is currently listed.