### PR TITLE
Fix dead link in Data Modeling 2

### DIFF
--- a/databases/data-modeling-2.md
+++ b/databases/data-modeling-2.md
@@ -32,7 +32,7 @@ Watch the first 3 sections:
 Then read these 2 tutorials:
 
 - https://wsvincent.com/database-design-tutorial-for-beginners/
-- https://www.ntu.edu.sg/home/ehchua/programming/sql/Relational_Database_Design.html
+- https://personal.ntu.edu.sg/ehchua/programming/sql/Relational_Database_Design.html
 
 #### Data modeling walkthrough
 


### PR DESCRIPTION
Currently the NTU link redirects [to a 404 notice](https://personal.ntu.edu.sg/404.html) that NTU staff pages have been moved to a new URL, this PR updates it to the newer one