### PR TITLE
Fix typo in Eventonica README for Part 8

### DIFF
--- a/projects/eventonica/README.md
+++ b/projects/eventonica/README.md
@@ -47,5 +47,5 @@ You'll work on this project over the next several weeks. The features will remai
 
 ## Optional Assignments
 
-- [Part 8 - API Testing](./eventonica-part8-api-testind.md) - 🐣 New in 2021
+- [Part 8 - API Testing](./eventonica-part8-api-testing.md) - 🐣 New in 2021
 - [Integrate the Ticketmaster API](./eventonica-part-4-apis.md) to allow the user to create events from real data (originally Part 4)


### PR DESCRIPTION
Currently the link for Part 8 points to `eventonica-part8-api-testind.md`, this PR fixes "testind" to "testing"