### PR TITLE
Remove duplicate Todo component, + info in parens

### DIFF
--- a/react-js/react-part4-full-apps.md
+++ b/react-js/react-part4-full-apps.md
@@ -110,13 +110,6 @@ import React from 'react';
 import Todo from './Todo';
 import './App.css';
 
-class Todo extends React.Component {
-  render() {
-    const { todo } = this.props;
-    return <div>{todo.text}</div>;
-  }
-}
-
 class App extends React.Component {
   constructor(props) {
     super(props);
@@ -141,7 +134,7 @@ class App extends React.Component {
 export default App;
 ```
 
-You should see the heading and a single todo.
+You should see the heading and a single todo. ( If you do not, refresh the chrome tab )
 
 #### Adding isCompleted
 


### PR DESCRIPTION
Duplicated Todo component in App.js after it has already been imported from Todo.js and will generate an error when attempting to declare it again. Removing it from App.js resolves the error. The Todo app may not render without refreshing the chrome tab that the default App.js was rendered in ( probably due to cache ).