### PR TITLE
Time Updates

### DIFF
--- a/onboarding/asking-good-questions.md
+++ b/onboarding/asking-good-questions.md
@@ -8,8 +8,8 @@ About 2 hours, 15 min
 - 9 minutes for StackOverflow video
 - 16 minutes for Documentation video
 - 20 minutes to read Julia Evans' article
-- 40 minutes for Independent Practice
-- 15 minutes to check for understanding
+- 30 minutes for Independent Practice 
+- 10 minutes to check for understanding
 
 ### Prerequisites
 


### PR DESCRIPTION
I think the times are a bit inflated in this section.  

These seem more accurate:
- 30 minutes for Independent Practice  (was 40)
- 10 minutes to check for understanding (was 15)