### PR TITLE
add specific instructions for creating zshrc

### DIFF
--- a/projects/week-1-worksheet.md
+++ b/projects/week-1-worksheet.md
@@ -65,7 +65,8 @@ the steps and/or ask for help before trying the following steps below.
 
 You should be using vim or another editor to edit your `.zshrc` file as you go.
 If you want to use vim, see the references in Part 0 with an intro to vim
-commands.
+commands. If you do use vim, you can open `.zshrc` in vim from a terminal with
+`vim ~/.zshrc` and proceed from there!
 
 Make sure you have added at least one of each:
 

--- a/projects/week-1-worksheet.md
+++ b/projects/week-1-worksheet.md
@@ -43,6 +43,30 @@ Here are links to  a lesson that should be completed before this lesson:
 
 ### Part 1 - change your zsh profile
 
+To help you get started, create an empty `.zshrc` file in your home directory like this:
+
+    touch ~/.zshrc
+
+You can add a definition for a single environment variable like this:
+
+    echo "HELLO=WORLD" >> ~/.zshrc
+
+And then apply the changes from your .zshrc with:
+
+    source ~/.zshrc
+
+Test the changes worked by checking the contents of the HELLO variable in your shell with:
+
+    echo $HELLO
+    WORLD
+
+The value should be "WORLD". If you do not see the same output as above, retry
+the steps and/or ask for help before trying the following steps below.
+
+You should be using vim or another editor to edit your `.zshrc` file as you go.
+If you want to use vim, see the references in Part 0 with an intro to vim
+commands.
+
 Make sure you have added at least one of each:
 
 - [ ] a custom environment variable
@@ -50,7 +74,10 @@ Make sure you have added at least one of each:
 - [ ] a new terminal prompt
 - [ ] a new alias
 
-In your terminal, use the commands to prove your environment variable, \$PATH file, and alias work. Make sure those lines and your custom prompt are in the terminal window at the same time, and save a screen shot of it to show your work.
+In your terminal, use the commands to prove your environment variable, \$PATH
+file, and alias work. Make sure those lines and your custom prompt are in the
+terminal window at the same time, and save a screen shot of it to show your
+work.
 
 ### Part 2 - Set up a text file using only zsh and vim
 


### PR DESCRIPTION
Per [this comment](https://techtonicaorg.slack.com/archives/C4VAQ1VJ9/p1661212590971129) we noticed that members of the cohort were missing that they should be creating a `.zshrc` file. We want to add more explicit instructions to make sure they create the file.

There is [a bigger issue here pointed out by Stephen](https://techtonicaorg.slack.com/archives/C03H7Q16SJ0/p1660094695367829?thread_ts=1660074142.991999&cid=C03H7Q16SJ0) that we could rework this lesson to have a more explicit goal and success criteria. I do not agree/attempt to take on that scope. I'm just trying to do the bare minimum of adding a more explicit goal.

I hope others can expand from here: https://techtonicaorg.slack.com/archives/C03H7Q16SJ0/p1660094695367829?thread_ts=1660074142.991999&cid=C03H7Q16SJ0