### PR TITLE
Add line to remove .git to prevent nested git proj

### DIFF
--- a/projects/weather-app.md
+++ b/projects/weather-app.md
@@ -48,6 +48,7 @@ It should have a responsive design.
 ### For the Frontend
 - [ ] Inside the main folder of your project create a folder called client
 - [ ] Inside your client folder initialize a create-react-app server in React 
+- [ ] `cd` into your client folder and remove the .git folder by completing the following command: `rm -rf .git`
 
 ## Part 1 - Connecting the API in the backend
 - [ ] Inside the server folder in your server.js file do a fetch request to the Weather API


### PR DESCRIPTION
As the instructions currently are, some might forget to remove the .git folder after doing creating a new project using create-react-app. This line ensures folks don't accidentally create a nested git directory