### PR TITLE
Recipe page project - fix formatting bug

### DIFF
--- a/projects/recipe-page/phase-1-html-prompt.md
+++ b/projects/recipe-page/phase-1-html-prompt.md
@@ -12,7 +12,7 @@ None
 
 ### Primary Goals
 
-1. Learning to use main HTML elements such as <h1></h1>, <div></div>, <ul></ul>, <ol></ol>, <li></li> <p></p>, <img>, etc.
+1. Learning to use main HTML elements such as `<h1></h1>`, `<div></div>`, `<ul></ul>`, `<ol></ol>`, `<li></li>` `<p></p>`, `<img>`, etc.
 2. Basic CSS, like rules for divs and IDs or implementing CSS elements like background color
 3. Understanding working with different containers
 4. Using GitHub to commit and push code, plus making a branch


### PR DESCRIPTION
Add code backticks around html tag references to ensure formatting. Without the backticks, the README has improper spacing formatting

Testing Notes: 
- ensure that [the new README ](https://github.com/Techtonica/curriculum/blob/f2fc842ee8f1a48825a1e255c7c6ed24da2afcb8/projects/recipe-page/phase-1-html-prompt.md)has proper formatting as shown in "After"

## Before
<img width="875" alt="Screenshot 2024-01-29 at 11 54 59 AM" src="https://github.com/Techtonica/curriculum/assets/41805952/7b5cf621-5b49-41c2-bc9d-86e853560d94">


## After
<img width="861" alt="Screenshot 2024-01-29 at 11 54 49 AM" src="https://github.com/Techtonica/curriculum/assets/41805952/57dea919-4642-4cec-89f6-8836944ab5ae">
