### PR TITLE
Remove codesandbox references from react-game project and encourage git version control

### DIFF
--- a/projects/react-game.md
+++ b/projects/react-game.md
@@ -14,7 +14,7 @@ Here are some [examples](https://bg.reactjs.org/community/examples.html).
 
 **Kindly avoid choosing the BMI calculator from the examples provided above, as it may be associated with sensitive issues such as racism and sizeism.**
 
-You can start this app in codeSandbox, codePen, replit.com, etc and then this week you'll learn how to build React apps locally and you can move the ode to your local drive.
+We encourage you to use git version control and GitHub to save your progress as you build up your work. This way you'll work on testing out React in your text editors locally.
 
 ### Minimum Requirements
 

--- a/projects/react-game.md
+++ b/projects/react-game.md
@@ -14,7 +14,7 @@ Here are some [examples](https://bg.reactjs.org/community/examples.html).
 
 **Kindly avoid choosing the BMI calculator from the examples provided above, as it may be associated with sensitive issues such as racism and sizeism.**
 
-We encourage you to use git version control and GitHub to save your progress as you build up your work. This way you'll work on testing out React in your text editors locally.
+We encourage you to use git version control and GitHub to save your progress as you build up your work. This way you can test React out in your local text editors.
 
 ### Minimum Requirements
 


### PR DESCRIPTION
Remove any references telling participants to start their project in a repl, such as codesandbox, codepen, replit, etc. Instead, encourage participants to start their project locally in order to test React and to utilize git version control to save all progress.