### PR TITLE
Resolving Issue #2158 - Standardizing Link Names in Supplemental Materials Section

### DIFF
--- a/open-source/open-source.md
+++ b/open-source/open-source.md
@@ -58,9 +58,9 @@ This table includes some examples of companies with large OSPOs, but these are j
 
 ## Supplemental Materials Not Listed Above
 
-- https://roshanjossey.github.io/first-contributions/#project-list
-- https://publiclab.github.io/community-toolbox/#r=all
-- https://up-for-grabs.net/#/tags/javascript
+- [](https://roshanjossey.github.io/first-contributions/#project-list)
+- [](https://publiclab.github.io/community-toolbox/#r=all)
+- [](https://up-for-grabs.net/#/tags/javascript)
 - [GitHub Explore](https://github.com/explore)
 - [Beginner-friendly open source JavaScript projects you can contribute to](https://github.com/MunGell/awesome-for-beginners#javascript)
 - [Practicing using GitHub to contribute to an Open Source project](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)

--- a/open-source/open-source.md
+++ b/open-source/open-source.md
@@ -58,13 +58,16 @@ This table includes some examples of companies with large OSPOs, but these are j
 
 ## Supplemental Materials Not Listed Above
 
-- [](https://roshanjossey.github.io/first-contributions/#project-list)
-- [](https://publiclab.github.io/community-toolbox/#r=all)
-- [](https://up-for-grabs.net/#/tags/javascript)
-- [GitHub Explore](https://github.com/explore)
-- [Beginner-friendly open source JavaScript projects you can contribute to](https://github.com/MunGell/awesome-for-beginners#javascript)
-- [Practicing using GitHub to contribute to an Open Source project](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
-- [Up for Grabs: Explore Open Source Projects and Jump In](https://up-for-grabs.net/)
+- [Article: Practicing using GitHub to contribute to an Open Source project](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+- [Github First Contributions Homepage (Maintained by: Github), Filter Applied: None](https://roshanjossey.github.io/first-contributions/#project-list)
+- [Public Lab Coding Community (Maintained by: 800+ contributors), Filter Applied: All](https://publiclab.github.io/community-toolbox/#r=all)
+- [Up For Grabs (Maintained by: Github users dahlbyk, shiftkey, jrusbatch & ritwik12), Filter Applied:Javascript](https://up-for-grabs.net/#/tags/javascript)
+- [Up for Grabs (Maintained by: Github users dahlbyk, shiftkey, jrusbatch & ritwik12), Filter Applied:None](https://up-for-grabs.net/)
+- [GitHub Explore (Maintained by: Github), Filter Applied: None](https://github.com/explore)
+- [Awesome for Beginners Github Repository (Maintained by: Shmavon Gazanchyan
+MunGell), Filter Applied: None](https://github.com/MunGell/awesome-for-beginners#javascript)
+
+
 
 ## Lesson
 

--- a/open-source/open-source.md
+++ b/open-source/open-source.md
@@ -59,13 +59,13 @@ This table includes some examples of companies with large OSPOs, but these are j
 ## Supplemental Materials Not Listed Above
 
 - [Article: Practicing using GitHub to contribute to an Open Source project](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
-- [Github First Contributions Homepage (Maintained by: Github), Filter Applied: None](https://roshanjossey.github.io/first-contributions/#project-list)
+- [Github First Contributions Homepage (Maintained by: Github), Filter Applied: project-list](https://roshanjossey.github.io/first-contributions/#project-list)
 - [Public Lab Coding Community (Maintained by: 800+ contributors), Filter Applied: All](https://publiclab.github.io/community-toolbox/#r=all)
 - [Up For Grabs (Maintained by: Github users dahlbyk, shiftkey, jrusbatch & ritwik12), Filter Applied:Javascript](https://up-for-grabs.net/#/tags/javascript)
 - [Up for Grabs (Maintained by: Github users dahlbyk, shiftkey, jrusbatch & ritwik12), Filter Applied:None](https://up-for-grabs.net/)
 - [GitHub Explore (Maintained by: Github), Filter Applied: None](https://github.com/explore)
 - [Awesome for Beginners Github Repository (Maintained by: Shmavon Gazanchyan
-MunGell), Filter Applied: None](https://github.com/MunGell/awesome-for-beginners#javascript)
+MunGell), Filter Applied: Javascript](https://github.com/MunGell/awesome-for-beginners#javascript)
 
 
 


### PR DESCRIPTION
## Overview  
This pull request addresses [Issue #2158](https://github.com/Techtonica/curriculum/issues/2158) by updating the links in the **Supplemental Materials** section of the open-source curriculum. The updates standardize the naming conventions for the links, improving consistency and usability.

## What Was Done  

1. **Link Updates:**  
   - Revised all links in the **Supplemental Materials** section to follow a consistent format:  
   - Include the name of the list.   
   - Display the creator/maintainer of the resource.  
    - Indicate any filters applied by the specific link.  

2. **Consistency Improvements:**  
   - Improved readability and navigability of the list by applying a uniform naming structure.  

3. **Post-PR #2153 Adjustments:**  
   - Incorporated changes on top of the revised list structure introduced in PR #2153, ensuring compatibility with the updated content.

## Status  
This pull request is ready for review.  
