### PR TITLE
Update Broken Links on React Part 4 - Components & Hierarchies

### DIFF
--- a/react-js/react-part-4-component-hierarchies.md
+++ b/react-js/react-part-4-component-hierarchies.md
@@ -138,7 +138,7 @@ Note that the above method is also how you would deal with **sibling communicati
 
 ##### How to use `props.children`
 
-1. Read [React This Props Children](https://codeburst.io/a-quick-intro-to-reacts-props-children-cb3d2fce4891)
+1. [Read React this.props.children](https://codeburst.io/a-quick-intro-to-reacts-props-children-cb3d2fce4891)
 1. Watch this 4 min video, [React Tutorial 13: `props.children`](https://www.youtube.com/watch?v=Sq0FoUPxj_c)
 1. [Read the React Docs on Children](https://react.dev/learn/choosing-the-state-structure#avoid-deeply-nested-state)
 

--- a/react-js/react-part-4-component-hierarchies.md
+++ b/react-js/react-part-4-component-hierarchies.md
@@ -138,9 +138,9 @@ Note that the above method is also how you would deal with **sibling communicati
 
 ##### How to use `props.children`
 
-1. Read [React This Props Children](https://learn.co/lessons/react-this-props-children)
+1. Read [React This Props Children](https://codeburst.io/a-quick-intro-to-reacts-props-children-cb3d2fce4891)
 1. Watch this 4 min video, [React Tutorial 13: `props.children`](https://www.youtube.com/watch?v=Sq0FoUPxj_c)
-1. [Read the React Docs on Children](https://reactjs.org/docs/composition-vs-inheritance.html#children) (5 min read. Just read the first section on Containment, but not about Specialization.)
+1. [Read the React Docs on Children](https://react.dev/learn/choosing-the-state-structure#avoid-deeply-nested-state)
 
 The ability for components to receive and render child elements is one of the most important feature of React. This makes it really easy to create reusable components. All we need to do is include data between the opening and closing tags of a parent component, and it will automatically get passed as a prop called `children`.
 


### PR DESCRIPTION
This PR is for [issue 2231](https://github.com/Techtonica/curriculum/issues/2231). 

It is addressing the issue of fixing the broken/ outdated links. 

There were additional small edits for formatting. 

Here is a demonstration **before** the fix: 

![reactissuereport](https://github.com/user-attachments/assets/63221ab0-d21c-4a6a-aa98-4a900cc7f818)


Here is a demonstration **after** the fix: 

![completedreactissue](https://github.com/user-attachments/assets/483f8c60-2dd3-4409-b7e5-9d7ff7302092)



