### PR TITLE
docs: fix typos in docs

### DIFF
--- a/javascript/newer-JS-features.md
+++ b/javascript/newer-JS-features.md
@@ -99,7 +99,7 @@ Math.max(...[2, 3, 4]); // 4 (spread expands array into separate arguments)
 
 Spread in array literals creates a new array using an existing array. It basically spreads the elements from one array into a new array.
 Let's look an example -
-Here, I've 2 arrays primaryColors and secondaryColors. allColors array contain all the elemnts from primaryColors and secondaryColors. ... spread the values into separate arguments. allColors contains copy of primaryColors and secondarycolors but the original arrays remains unchanged!
+Here, I've 2 arrays primaryColors and secondaryColors. allColors array contain all the elements from primaryColors and secondaryColors. ... spread the values into separate arguments. allColors contains copy of primaryColors and secondarycolors but the original arrays remains unchanged!
 
 ```javascript
 const primaryColors = ['red', 'green', 'blue'];
@@ -187,7 +187,7 @@ let secondMax = numbers[1];
 
 With ES6 new syntax, extracting or singling out values becomes much easier. Instead of doing `arr[0]` or `arr[1]` we can do:
 
-```javscript
+```javascript
 const [max, secondMax, ...lowerNumbers] = numbers;
 console.log(max); // Here max is holding the value of numbers[0];
 console.log(secondMax); // 5

--- a/javascript/require-and-import-mini-lesson.md
+++ b/javascript/require-and-import-mini-lesson.md
@@ -129,7 +129,7 @@ While there are many differences between `require` and `import`, which are det
 
 #### Chart of the Differences
 
-For your convienience, here is a detailed chart of the differences between `require` and `import`.
+For your convenience, here is a detailed chart of the differences between `require` and `import`.
 
 | REQUIRE                                                                                                      | IMPORT                                                                  |
 | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |

--- a/javascript/restaurant recommender/design_yelp.py
+++ b/javascript/restaurant recommender/design_yelp.py
@@ -175,7 +175,7 @@ class RestaurantRecommender(object):
         # .. get the top five
         if len(user.ratings) == 0: return []
 
-        # prioritize restauraunts
+        # prioritize restaurants
         user_heap = self.prioritize(user.ratings)
 
         # get top five restaurants of users

--- a/web/css-part-2.md
+++ b/web/css-part-2.md
@@ -48,7 +48,7 @@ You are not expected to have this all memorized at the end of the lesson. Right 
 - [:active pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:active)
 - [::before pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::before)
 
-1. Although CSS issues tend to be relatively easy to Google, https://css-tricks.com/ has one of the best collections of **CSS Guides**. Take 15 minutes total to look at some of the most popular articles. You don't need to read them throughly, but instead get a feel for some of the common problems you'll be solving.
+1. Although CSS issues tend to be relatively easy to Google, https://css-tricks.com/ has one of the best collections of **CSS Guides**. Take 15 minutes total to look at some of the most popular articles. You don't need to read them thoroughly, but instead get a feel for some of the common problems you'll be solving.
 
 - Flexbox: https://css-tricks.com/snippets/css/a-guide-to-flexbox/
 - Centering: https://css-tricks.com/centering-css-complete-guide/

--- a/web/html-forms.md
+++ b/web/html-forms.md
@@ -30,7 +30,7 @@
 HTML Form is one of the most popular ways to gather user information and send it to an application. It is the most efficient way to let the user enter the data. For example, it can be used to collect things like a name and email in a sign-up form.
 
 **Start with some interactive practice**
-Helful Codecademy lessons:
+Helpful Codecademy lessons:
 
 - [HTML Forms](https://www.codecademy.com/courses/learn-html/lessons/html-forms)
 - [Form Validation](https://www.codecademy.com/courses/learn-html/lessons/html-form-validation)


### PR DESCRIPTION
###  Description

This PR fixes a bunch of typos in the curriculum docs—makes it easier to read and more professional.

###  Changes Made

- **javascript/newer-JS-features.md**:  "javscript" → "javascript" , "elemnts" → "elements"
- **javascript/require-and-import-mini-lesson.md**: "convienience" " → "convenience" 
- **javascript/restaurant recommender/design_yelp.py**:  "restauraunts" → "restaurants" 
- **web/css-part-2.md**:  "throughly" → "thoroughly"  
- **web/html-forms.md**:  "Helful" → "Helpful"