### PR TITLE
eslint: ignore nested dist directories

### DIFF
--- a/pair-programming/week-7/react-forms-continued/eslint.config.js
+++ b/pair-programming/week-7/react-forms-continued/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist"]),
+  globalIgnores(["**/dist/**"]),
   {
     files: ["**/*.{js,jsx}"],
     extends: [


### PR DESCRIPTION
Extend ESLint ignore pattern to cover nested dist directories and avoid linting build artifacts in subfolders