### PR TITLE
Update clone command URL in README.md

### DIFF
--- a/projects/2023TemplateWithVite/README.md
+++ b/projects/2023TemplateWithVite/README.md
@@ -6,7 +6,7 @@
 
 ### To create the whole project
 
-1. Go to your project directory in your terminal and run the command `git clone https://github.com/Yosolita1978/Template2023React-Vite.git NAMENEWDIRECTORY`
+1. Go to your project directory in your terminal and run the command `git clone https://github.com/Techtonica/curriculum/tree/main/projects/2023TemplateWithVite NAMENEWDIRECTORY`
 
 2. To remove the source code git out of the project directory, run the command `rm -rf .git`
 


### PR DESCRIPTION
### 📝 Description

This PR updates the git clone instructions to point to this curriculum repo's updated version of the 2023TemplateWithVite files

### 🔂 Changes Made

Changed the git clone instruction in the README.

### ⚙️ Related Issue

### 🍏 Type of Change

- Documentation update

### 🎁 Acceptance Criteria

- Now the clone link should point to https://github.com/Techtonica/curriculum/tree/main/projects/2023TemplateWithVite

### 🧪 How to test or what to evaluate

1. Navigate to projects/2023TemplateWithVite
2. See the initial git clone instructions point to https://github.com/Techtonica/curriculum/tree/main/projects/2023TemplateWithVite

### 🚀 Repo Notes (if applicable)

- This quick update is needed because we will review these project files with the cohort this evening

### 📸 Screenshots (if applicable)



### ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [ ] I have commented my code where necessary.
- [ ] I have tested my code locally and verified the website is working as expected.
- [ ] (if applicable) I have added documentation in the README.
- [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [ ] (if applicable) New and existing unit tests pass locally with my changes.
