### PR TITLE
Add three options for copying project folder

### DIFF
--- a/projects/2023TemplateWithVite/README.md
+++ b/projects/2023TemplateWithVite/README.md
@@ -14,7 +14,7 @@
    git clone https://github.com/Techtonica/curriculum.git
    ```
 
-   b. Use a downloader such as https://download-directory.github.io (a popular but unofficial github service), and expand the zip file.
+   b. Use a downloader such as https://download-directory.github.io (a popular but unofficial GitHub service), and expand the zip file.
 
    c. Do a sparse clone (see https://git-scm.com/docs/sparse-checkout)
 


### PR DESCRIPTION
### 📝 Description

Since we cannot directly `git clone` this subfolder, three options were given for how to get it.

### 🔂 Changes Made

Project README now has a more detailed step 1 for downloading the project folder.

### ⚙️ Related Issue

- Issue Number: #2605

### 🍏 Type of Change

- Bug fix

### 🎁 Acceptance Criteria

- Readme for the project now lists three ways of downloading the project folder
    - cloning the entire curriculum repo
    - using a downloader service
    - sparse cloning


### 🧪 How to test or what to evaluate

View the instructions in the 2023TemplateWithVite Readme and evaluate for clarity and accuracy

### 🚀 Repo Notes (if applicable)

### 📸 Screenshots (if applicable)


### ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [ ] I have commented my code where necessary.
- [x] I have tested my code locally and verified the website is working as expected.
- [ ] (if applicable) I have added documentation in the README.
- [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [ ] (if applicable) New and existing unit tests pass locally with my changes.
