### PR TITLE
Add missing 'react-dom' dependency to Working_with_React_Testing_Library package.json

### DIFF
--- a/code-challenges/Week_8/Working_with_React_Testing_Library/package.json
+++ b/code-challenges/Week_8/Working_with_React_Testing_Library/package.json
@@ -12,12 +12,14 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
   "devDependencies": {
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@vitejs/plugin-react": "^4.2.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.0"
   }


### PR DESCRIPTION
The package.json for the Working_with_React_Testing_Library code challenge includes react and react-dom in devDependencies instead of dependencies. This causes the app to fail at runtime because react-dom is not available when the app loads (devDependencies are not installed in production). Additionally, the react-dom dependency is missing from the dependencies section. This change moves react-dom to dependencies, aligning with standard React project setup and ensuring the app works with `npm run dev` or `npm start`.