### PR TITLE
[Issue 2500] Add week 13 quizzes to curriculum

### DIFF
--- a/objectives/quizzes/week_13/react_devtools_chrome_extension.md
+++ b/objectives/quizzes/week_13/react_devtools_chrome_extension.md
@@ -1,0 +1,13 @@
+Install [React Dev Tools Chrome Extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en). Go to [Airbnb.io](Airbnb.io). Open your Chrome Developer Tools. Click into ">>" tab and click your "Components" tab.
+
+Complete the following tasks:
+- Change the leading "Airbnb.io" header (next to the Airbnb logo in bold text in the upper left corner) to your first and last name.
+- Change the first image block's src to reference a different image.
+- Change the image's width to a smaller size less than 100%.
+- Change the Text Component's text in the div underneath the photo you've just updated.
+
+[insert_image_here]
+
+Upload a screenshot of your changes [into this form](). Please make sure your file is named <yourname_week13_react-dev-tools>.extension.
+
+For example: marsh_mallow_week13_react-dev-tools.jpg

--- a/objectives/quizzes/week_13/react_devtools_chrome_extension.md
+++ b/objectives/quizzes/week_13/react_devtools_chrome_extension.md
@@ -6,8 +6,8 @@ Complete the following tasks:
 - Change the image's width to a smaller size less than 100%.
 - Change the Text Component's text in the div underneath the photo you've just updated.
 
-[insert_image_here]
+<img width="2048" height="1155" alt="airbnb_doggy_image" src="https://github.com/user-attachments/assets/3ebfb8c5-3505-4e62-9b49-e5474959f092" />
 
-Upload a screenshot of your changes [into this form](). Please make sure your file is named <yourname_week13_react-dev-tools>.extension.
+Upload a screenshot of your changes [into this form](https://forms.gle/KZLASfjc815kYx7u9). Please make sure your file is named <yourname_week13_react-dev-tools>.extension.
 
 For example: marsh_mallow_week13_react-dev-tools.jpg


### PR DESCRIPTION
### 📝 Description
Currently week 13 quizzes are in the STEM's personal GitHub and previous TAPM's repos, sandbox, etc and not living in the curriculum. This PR moves that content directly into the curriculum independent of employee access/ownership and encourages participant use of git and the terminal during foundational learning

[Staff Examples for Week 13](https://github.com/Techtonica/Examples/tree/main/quizzes/week_13)

### ⚙️ Related Issue
Issue Number: #2500

### 🎁 Acceptance Criteria
- Move quizzes into their own location with snake_casing for easier terminal navigation.
- Each respective quiz should contain starter code - make main default.
- Example solutions should live in the example repo accessible to staff only - remove answers branches and move to a respective area in examples repo.